### PR TITLE
Add npm scripts for automatic fix linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "homepage": "https://github.com/Mudano/ui-react#readme",
   "scripts": {
     "css:lint": "stylelint 'src/**/*.scss'",
+    "css:lint:fix": "yarn css:lint -- --fix",
     "css:build": "yarn css:lint && node-sass-chokidar src/ -o src/",
     "css:watch": "yarn css:build && node-sass-chokidar src/ -o src/ --watch --recursive",
     "js:lint": "eslint ./src --cache",
+    "js:lint:fix": "yarn js:lint -- --fix",
     "js:clean": "rm -rf ./dist",
     "js:build": "yarn js:clean && yarn js:lint && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --ignore *.scss,*.story.js,*.test.js",
     "storybook:build": "yarn js:lint && build-storybook",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   "homepage": "https://github.com/Mudano/ui-react#readme",
   "scripts": {
     "css:lint": "stylelint 'src/**/*.scss'",
-    "css:lint:fix": "yarn css:lint -- --fix",
+    "css:lint-fix": "yarn css:lint --fix",
     "css:build": "yarn css:lint && node-sass-chokidar src/ -o src/",
     "css:watch": "yarn css:build && node-sass-chokidar src/ -o src/ --watch --recursive",
     "js:lint": "eslint ./src --cache",
-    "js:lint:fix": "yarn js:lint -- --fix",
+    "js:lint-fix": "yarn js:lint --fix",
     "js:clean": "rm -rf ./dist",
     "js:build": "yarn js:clean && yarn js:lint && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --ignore *.scss,*.story.js,*.test.js",
     "storybook:build": "yarn js:lint && build-storybook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7954,13 +7954,6 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-watch@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
-
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"


### PR DESCRIPTION
These 2 new npm scripts are not automatic, in the sense that you need to run them manually, so there is no chance of committing linting changes by mistake, without noticing it

Based on the fact that all our code base will be linted, the lint fix command will save time to developers

--fix flag doesn't fix every single problem, only "easy" ones, like indentation, whitespace, etc. Exactly those ones that are a nuance to fix manually)