### PR TITLE
Fix test helper to match class name naming convention, also fix DemoC…

### DIFF
--- a/src/components/DemoComponent/DemoComponent.js
+++ b/src/components/DemoComponent/DemoComponent.js
@@ -9,9 +9,9 @@ const DemoComponent = ({
     isDisabled,
     onClick,
 }) => (
-    <div role="button" tabIndex={0} className={cx('uir-DemoComponent', { 'uir-DemoComponent-disabled': isDisabled })} onClick={onClick} onKeyPress={onClick}>
-        <div className="ui-demo-component--title"><h2>{title}</h2></div>
-        <div className="ui-demo-component--content">{children}</div>
+    <div role="button" tabIndex={0} className={cx('uir-demo-component', { 'uir-demo-component--disabled': isDisabled })} onClick={onClick} onKeyPress={onClick}>
+        <div className="uir-demo-component--title"><h2>{title}</h2></div>
+        <div className="uir-demo-component--content">{children}</div>
     </div>
 );
 

--- a/src/components/DemoComponent/DemoComponent.scss
+++ b/src/components/DemoComponent/DemoComponent.scss
@@ -1,9 +1,9 @@
-.uir-DemoComponent {
+.uir-demo-component {
     width: 200px;
     padding: 20px;
     border: 1px solid black;
 
-    &.uir-DemoComponent-disabled {
+    &.uir-demo-component--disabled {
         opacity: .4;
     }
 }

--- a/src/components/DemoComponent/DemoComponent.test-int.js
+++ b/src/components/DemoComponent/DemoComponent.test-int.js
@@ -6,6 +6,6 @@ Feature('DemoComponent');
 Scenario('test default demo component', (I, mapper) => {
     I.amOnPage(mapper.demoComponent.default);
     within({ frame: '#storybook-preview-iframe' }, () => {
-        I.see('Custom title', '.ui-demo-component');
+        I.see('Custom title', '.uir-demo-component');
     });
 });

--- a/src/components/DemoComponent/DemoComponent.test.js
+++ b/src/components/DemoComponent/DemoComponent.test.js
@@ -24,7 +24,7 @@ describe('DemoComponent', () => {
                 <DemoComponent />
             ));
 
-            expect(wrapper.find('.ui-demo-component--title')).to.have.text('Demo');
+            expect(wrapper.find('.uir-demo-component--title')).to.have.text('Demo');
         });
 
         it('renders provided title text', () => {
@@ -32,7 +32,7 @@ describe('DemoComponent', () => {
                 <DemoComponent title="Test title text!" />
             ));
 
-            expect(wrapper.find('.ui-demo-component--title')).to.have.text('Test title text!');
+            expect(wrapper.find('.uir-demo-component--title')).to.have.text('Test title text!');
         });
     });
 

--- a/test/unit/utils/getClassNameFromBoolPropKey.js
+++ b/test/unit/utils/getClassNameFromBoolPropKey.js
@@ -1,10 +1,21 @@
 /**
+ * Convert camelCased string to hyphen-separated string.
+ * Taken from https://stackoverflow.com/a/36731580
+ * @param {String} text The string to convert
+ */
+function convertCamelCaseToDash(text) {
+    return text.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase();
+}
+
+/**
  * Get className derived from Component name and a boolean prop key name
  * @param {React.Component|Function} Component The component to test.
  * @param {String} propKey A props key.
  */
 export default (Component, propKey) => {
-    const nameFromPropKey = propKey.indexOf('is') === 0 ? propKey.replace('is', '').toLowerCase() : propKey;
+    const nameFromPropKey = propKey.indexOf('is') === 0 ?
+        convertCamelCaseToDash(propKey.replace('is', '')) :
+        propKey;
 
-    return `uir-${Component.name}-${nameFromPropKey}`;
+    return `uir-${convertCamelCaseToDash(Component.name)}--${nameFromPropKey}`;
 };


### PR DESCRIPTION
…omponent class names to match the naming convention

The test will now check for class names matching "uir-component-name--modifier-name"