### PR TITLE
Add temporary fix for travis failing to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: node_js
 node_js:
     - "8"
+sudo: required
+dist: trusty
+addons:
+    chrome: stable
 cache: yarn
 install:
     - yarn install
 before_script:
+    - "sudo chown root /opt/google/chrome/chrome-sandbox"
+    - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
     - yarn test:int-setup &
     - sleep 3
 script:


### PR DESCRIPTION
Due to travis applying Meltdown security patches, our builds are being rerouted to machines with sudo:required. This causes headless Chrome to fail to start because of wrong permissions on chrome-sandbox.
This fix is temporary. Running on sudo:false is quicker so we should go back to that when it's working again.
See here for more details:
https://blog.travis-ci.com/2018-01-08-travis-response-meltdown-spectre