### PR TITLE
Travis config fix for ghpages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
     - yarn storybook:build
 deploy:
     provider: pages
-    skip_cleanup: true
-    github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-    local_dir: storybook-static
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+    local-dir: storybook-static
     on:
         branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ deploy:
     provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-    local_dir: ${TRAVIS_BUILD_DIR}/storybook-static
+    local_dir: storybook-static
     on:
         branch: master


### PR DESCRIPTION
There were some changes done to Travis so that it is no longer
needed to reference the build directory for github pages deployment,
see:
travis-ci/docs-travis-ci-com@6eb6a93#diff-6c7d1ade9d9ff1ac77efbb831400f843R46