### PR TITLE
New automation workflow config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,26 +1,15 @@
-<!-- Remember to use a meaningful title that references the story ID (or story IDs) that this PR fixes. For example: [AB-123] Adds some cool new feature -->
+<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->
 
-* **What kind of change does this PR introduce?**
-<!-- Bug fix, feature, docs update, fixing tests etc. Answer on the line below -->
-
-
-* **Briefly, what feature or bug did this fix?**
-<!-- e.g. 'This adds a new feature to some cool stuff'. Answer on the line below -->
+# Backwards Compatibility Implications    <!-- List backwards compatibility issues, or `None` if there are none. -->
 
 
-* **What technical changes were made?**
-<!-- e.g. Added a new set of front end components and an API endpoint to get some cool data. Answer on the line below -->
+# New Features    <!-- List new features, or `None` if there are none. -->
 
 
-* **Anything else that reviewers or your future self needs to be aware when looking at this PR?**
-<!-- Explain anything that would be useful to know if someone needs to debug this feature at a later date. Put 'None' if there is no useful extra information. Answer on the line below -->
+# Bug Fixes    <!-- List any bug fixes, or `None` if there are none. -->
 
 
-* **Confirm you have checked the following:**
-<!-- Tick each that applies once you have raised the PR or replace ‘[ ]’ with ‘[x]’ -->
-- [ ] Tests for the changes have been added (for bug fixes / features)
-- [ ] Docs have been added / updated (for bug fixes / features)
-- [ ] These changes touch core code
-- [ ] These changes require a database schema change
-- [ ] These changes require infrastructure changes
-- [ ] These changes require a manual step in the release process
+# Performance Improvements    <!-- List performance improvements, or `None` if there are none. -->
+
+
+# Miscellaneous    <!-- List anything else changed in this PR, for example 'Updated documentation', or `None` if there are none. -->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,26 @@
+<!-- Remember to use a meaningful title that references the story ID (or story IDs) that this PR fixes. For example: [AB-123] Adds some cool new feature -->
+
+* **What kind of change does this PR introduce?**
+<!-- Bug fix, feature, docs update, fixing tests etc. Answer on the line below -->
+
+
+* **Briefly, what feature or bug did this fix?**
+<!-- e.g. 'This adds a new feature to some cool stuff'. Answer on the line below -->
+
+
+* **What technical changes were made?**
+<!-- e.g. Added a new set of front end components and an API endpoint to get some cool data. Answer on the line below -->
+
+
+* **Anything else that reviewers or your future self needs to be aware when looking at this PR?**
+<!-- Explain anything that would be useful to know if someone needs to debug this feature at a later date. Put 'None' if there is no useful extra information. Answer on the line below -->
+
+
+* **Confirm you have checked the following:**
+<!-- Tick each that applies once you have raised the PR or replace ‘[ ]’ with ‘[x]’ -->
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+- [ ] These changes touch core code
+- [ ] These changes require a database schema change
+- [ ] These changes require infrastructure changes
+- [ ] These changes require a manual step in the release process

--- a/COMMIT_MSG
+++ b/COMMIT_MSG
@@ -1,0 +1,35 @@
+# :icon: [STORY-ID] (If applied, this commit will...) <subject>
+# |<------           Using a MAXIMUM Of 72 Characters           ------>|
+
+
+# If the subject doesn’t give the full story, explain why the change is being made
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->|
+
+
+# IDs of any relevant tickets or http links to relevant resources
+# Example: This fixes task FL1-987
+
+
+# --- COMMIT END ---
+# To apply this template run the following command: `git config --local commit.template COMMIT_MSG`
+# Icon can be ONE of the following (If in doubt choose the first item that is relevant in the list).
+# :star:              ⭐️ when developing new or existing features
+# :bug:               🐛 when fixing a bug
+# :art:               🎨 when refactoring
+# :racehorse:         🐎 when improving performance or memory
+# :memo:              📝 when writing docs
+# :green_heart:       💚 when fixing the CI build
+# :white_check_mark:  ✅ when adding tests
+# :lock:              🔒 when dealing with security
+# :books:             📚 when upgrading or downgrading dependencies
+# :shirt:             👕 when removing linter warnings
+# --------------------
+# Remember to
+#  - Include the story ID in the subject line
+#  - Capitalize the subject line
+#  - Use the imperative mood in the subject line
+#  - Do not end the subject line with a period
+#  - Separate subject from body with a blank line
+#  - Use the body to explain what and why vs. how
+#  - Can use multiple lines with "-" for bullet points in body
+# --------------------

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ To get started run the following:
 
 You can then view the Storybook here: [http://localhost:6006/](http://localhost:6006/)
 
+#### Commit Template
+
+Use the commit template stored within the repo when commiting. Run the command `git config --local commit.template COMMIT_MSG` to use it.
+
 ### Testing
 
 To run unit tests use:


### PR DESCRIPTION
- adds an empty `CODEOWNERS` file which GitHub can use to enforce PR approval if core code is changed
- adds a pull request template which devs can follow when manually creating a PR
- adds a commit message template - this can be applied by running `git config --local commit.template COMMIT_MSG`

The `CODEOWNERS`, `PULL_REQUEST_TEMPLATE` and `COMMIT_MSG` files are intended to evolve with the project - e.g. if the PR template doesn't contain the right information, or it's too heavyweight, it can be changed.
