### PR TITLE
Change charcoal variable to correct colour

### DIFF
--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -7,7 +7,7 @@ $font-family: "DINOT", sans-serif !default;
 // --- COLOURS ---
 $white: #fff;
 $grey: #ccc !default;
-$charcoal: #3a333c !default;
+$charcoal: #2f2833 !default;
 $purple: #9a3cbb !default;
 $pink: #fd2a7d !default;
 $teal: #46bead !default;


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

 - Change `$charcoal` SASS variable to correct grey