### PR TITLE
Make builds fail if coverage not 100%

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -105,7 +105,7 @@ module.exports = (config) => {
             // with an exit code of 1 if not running in watch mode
             thresholds: {
                 // Set to `true` to not fail the test command when thresholds are not met
-                emitWarning: true,
+                emitWarning: false,
                 // Thresholds for all files
                 global: {
                     statements: 100,


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

_None_

**Miscellaneous**

- Change karma.config to make the unit test task fail if code coverage is less than 100%.
We've been running at 100% coverage, so let's ensure it stays that way.
