### PR TITLE
TextField and TextArea label appears by default

### DIFF
--- a/src/components/About.story.js
+++ b/src/components/About.story.js
@@ -199,11 +199,11 @@ React events can be found here: [https://reactjs.org/docs/events.html#supported-
 
 ### Boolean Flags
 
-Boolean props take one of two formats: \`hasProperty\` and \`isProperty\`.
+Boolean props generally take one of two formats: \`hasProperty\` and \`isProperty\`.
 
-We generally use \`has...\` when we're modifying a component e.g. \`hasHalo\`.
+We try to use \`has...\` when we're modifying a component e.g. \`hasHalo\`.
 
-And we use \`is...\` to, most often, toggle state e.g. \`isActive\`.
+And we try to use \`is...\` to, most often, toggle state e.g. \`isActive\`.
 
 ### Class Names
 

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -13,7 +13,7 @@ const propTypes = {
     className: PropTypes.string,
     componentRef: PropTypes.func,
     hasAutoHeight: PropTypes.bool,
-    hasLabelAlways: PropTypes.bool,
+    hasLabelOnFocus: PropTypes.bool,
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
     isReadOnly: PropTypes.bool,
@@ -50,7 +50,7 @@ const defaultProps = {
     className: null,
     componentRef: null,
     hasAutoHeight: false,
-    hasLabelAlways: false,
+    hasLabelOnFocus: false,
     isDisabled: false,
     isFullWidth: false,
     isReadOnly: false,
@@ -199,7 +199,7 @@ class TextArea extends Component {
 
     render() {
         const showLabel = (
-            this.props.hasLabelAlways ||
+            this.props.hasLabelOnFocus === false ||
             this.state.hasFocus ||
             this.state.hasMouseOver ||
             !this.state.value

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -10,10 +10,10 @@ import requiredIconAndTooltip from './RequiredIconAndTooltip';
 import './TextArea.scss';
 
 const propTypes = {
+    autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
     componentRef: PropTypes.func,
     hasAutoHeight: PropTypes.bool,
-    hasLabelOnFocus: PropTypes.bool,
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
     isReadOnly: PropTypes.bool,
@@ -47,10 +47,10 @@ const propTypes = {
 };
 
 const defaultProps = {
+    autoHideLabel: false,
     className: null,
     componentRef: null,
     hasAutoHeight: false,
-    hasLabelOnFocus: false,
     isDisabled: false,
     isFullWidth: false,
     isReadOnly: false,
@@ -199,7 +199,7 @@ class TextArea extends Component {
 
     render() {
         const showLabel = (
-            this.props.hasLabelOnFocus === false ||
+            this.props.autoHideLabel === false ||
             this.state.hasFocus ||
             this.state.hasMouseOver ||
             !this.state.value

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -36,7 +36,7 @@ stories.add(
 stories.add(
     'Auto Hide Label',
     storyWrapper(
-        'Label will hide when the input does not have focus with the autoHideLabel prop.',
+        'Use `autoHideLabel` to hide the field label when the input loses focus.',
         <TextArea
             label="Always has a label"
             value="my example value"

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -34,13 +34,13 @@ stories.add(
 );
 
 stories.add(
-    'Label Always',
+    'Label On Hover',
     storyWrapper(
-        'Label can be forced to always appear with the hasLabelAlways prop.',
+        'Label will hide when the input does not have focus with the hasLabelOnFocus prop.',
         <TextArea
             label="Always has a label"
             value="my example value"
-            hasLabelAlways
+            hasLabelOnFocus
         />,
     ),
 );

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -36,10 +36,18 @@ stories.add(
 stories.add(
     'Auto Hide Label',
     storyWrapper(
-        'Use `autoHideLabel` to hide the field label when the input loses focus.',
+        `
+Use \`autoHideLabel\` to hide the field label when the input loses focus.
+
+_NB: label will not hide if there is no value._
+        `,
         <TextArea
-            label="Always has a label"
-            value="my example value"
+            label="Label will auto hide"
+            value="My label auto hides"
+            autoHideLabel
+        />,
+        <TextArea
+            label="Label without value"
             autoHideLabel
         />,
     ),

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -34,13 +34,13 @@ stories.add(
 );
 
 stories.add(
-    'Label On Hover',
+    'Auto Hide Label',
     storyWrapper(
-        'Label will hide when the input does not have focus with the hasLabelOnFocus prop.',
+        'Label will hide when the input does not have focus with the autoHideLabel prop.',
         <TextArea
             label="Always has a label"
             value="my example value"
-            hasLabelOnFocus
+            autoHideLabel
         />,
     ),
 );

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -23,24 +23,24 @@ describe('TextArea', () => {
         expect(textArea.find('label').length).to.equal(0);
     });
 
-    it('always renders a label element if hasLabelAlways is true', () => {
-        const textField = shallow(<TextArea label="foo" value="bar" hasLabelAlways />);
+    it('does render a label element if hasLabelOnFocus is true and value is undefined', () => {
+        const textField = shallow(<TextArea label="foo" hasLabelOnFocus />);
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('does not render a label element if label provided put value is defined', () => {
-        const textArea = shallow(<TextArea label="test" value="example" />);
-        expect(textArea.find('label').length).to.equal(0);
+    it('does not render a label element if hasLabelOnFocus is true and value is defined', () => {
+        const textField = shallow(<TextArea label="foo" value="test" hasLabelOnFocus />);
+        expect(textField.find('label').length).to.equal(0);
     });
 
     it('renders a label element when there is value and textarea has focus', () => {
-        const textArea = shallow(<TextArea label="test" value="example" />);
+        const textArea = shallow(<TextArea label="test" value="example" hasLabelOnFocus />);
         textArea.find('textarea').simulate('focus');
         expect(textArea.find('label').length).to.equal(1);
     });
 
     it('renders a label element when there is value and TextArea has mouse over', () => {
-        const textArea = shallow(<TextArea label="test" value="example" />);
+        const textArea = shallow(<TextArea label="test" value="example" hasLabelOnFocus />);
         textArea.simulate('mouseEnter');
         expect(textArea.find('label').length).to.equal(1);
     });

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -23,24 +23,24 @@ describe('TextArea', () => {
         expect(textArea.find('label').length).to.equal(0);
     });
 
-    it('does render a label element if hasLabelOnFocus is true and value is undefined', () => {
-        const textField = shallow(<TextArea label="foo" hasLabelOnFocus />);
+    it('does render a label element if autoHideLabel is true and value is undefined', () => {
+        const textField = shallow(<TextArea label="foo" autoHideLabel />);
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('does not render a label element if hasLabelOnFocus is true and value is defined', () => {
-        const textField = shallow(<TextArea label="foo" value="test" hasLabelOnFocus />);
+    it('does not render a label element if autoHideLabel is true and value is defined', () => {
+        const textField = shallow(<TextArea label="foo" value="test" autoHideLabel />);
         expect(textField.find('label').length).to.equal(0);
     });
 
     it('renders a label element when there is value and textarea has focus', () => {
-        const textArea = shallow(<TextArea label="test" value="example" hasLabelOnFocus />);
+        const textArea = shallow(<TextArea label="test" value="example" autoHideLabel />);
         textArea.find('textarea').simulate('focus');
         expect(textArea.find('label').length).to.equal(1);
     });
 
     it('renders a label element when there is value and TextArea has mouse over', () => {
-        const textArea = shallow(<TextArea label="test" value="example" hasLabelOnFocus />);
+        const textArea = shallow(<TextArea label="test" value="example" autoHideLabel />);
         textArea.simulate('mouseEnter');
         expect(textArea.find('label').length).to.equal(1);
     });

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -16,7 +16,7 @@ import './TextField.scss';
 const propTypes = {
     className: PropTypes.string,
     componentRef: PropTypes.func,
-    hasLabelAlways: PropTypes.bool,
+    hasLabelOnFocus: PropTypes.bool,
     icon: PropTypes.element,
     isClearable: PropTypes.bool,
     isDisabled: PropTypes.bool,
@@ -58,7 +58,7 @@ const propTypes = {
 const defaultProps = {
     className: null,
     componentRef: null,
-    hasLabelAlways: false,
+    hasLabelOnFocus: false,
     icon: null,
     isClearable: false,
     isDisabled: false,
@@ -212,7 +212,7 @@ class TextField extends Component {
 
     render() {
         const showLabel = (
-            this.props.hasLabelAlways ||
+            this.props.hasLabelOnFocus === false ||
             this.state.hasFocus ||
             this.state.hasMouseOver ||
             !this.state.value

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -14,9 +14,9 @@ import requiredIconAndTooltip from './RequiredIconAndTooltip';
 import './TextField.scss';
 
 const propTypes = {
+    autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
     componentRef: PropTypes.func,
-    hasLabelOnFocus: PropTypes.bool,
     icon: PropTypes.element,
     isClearable: PropTypes.bool,
     isDisabled: PropTypes.bool,
@@ -56,9 +56,9 @@ const propTypes = {
 };
 
 const defaultProps = {
+    autoHideLabel: false,
     className: null,
     componentRef: null,
-    hasLabelOnFocus: false,
     icon: null,
     isClearable: false,
     isDisabled: false,
@@ -212,7 +212,7 @@ class TextField extends Component {
 
     render() {
         const showLabel = (
-            this.props.hasLabelOnFocus === false ||
+            this.props.autoHideLabel === false ||
             this.state.hasFocus ||
             this.state.hasMouseOver ||
             !this.state.value

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -77,13 +77,13 @@ stories.add(
 );
 
 stories.add(
-    'Label Always',
+    'Label On Hover',
     storyWrapper(
-        'Label can be forced to always appear with the hasLabelAlways prop.',
+        'Label will hide when the input does not have focus with the hasLabelOnFocus prop.',
         <TextField
             label="Always has a label"
             value="my example value"
-            hasLabelAlways
+            hasLabelOnFocus
         />,
     ),
 );

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -77,13 +77,13 @@ stories.add(
 );
 
 stories.add(
-    'Label On Hover',
+    'Auto Hide Label',
     storyWrapper(
-        'Label will hide when the input does not have focus with the hasLabelOnFocus prop.',
+        'Label will hide when the input does not have focus with the autoHideLabel prop.',
         <TextField
             label="Always has a label"
             value="my example value"
-            hasLabelOnFocus
+            autoHideLabel
         />,
     ),
 );

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -79,7 +79,7 @@ stories.add(
 stories.add(
     'Auto Hide Label',
     storyWrapper(
-        'Label will hide when the input does not have focus with the autoHideLabel prop.',
+        'Use `autoHideLabel` to hide the field label when the input loses focus.',
         <TextField
             label="Always has a label"
             value="my example value"

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -79,10 +79,18 @@ stories.add(
 stories.add(
     'Auto Hide Label',
     storyWrapper(
-        'Use `autoHideLabel` to hide the field label when the input loses focus.',
+        `
+Use \`autoHideLabel\` to hide the field label when the input loses focus.
+
+_NB: label will not hide if there is no value._
+        `,
         <TextField
-            label="Always has a label"
-            value="my example value"
+            label="Label will auto hide"
+            value="My label auto hides"
+            autoHideLabel
+        />,
+        <TextField
+            label="Label without value"
             autoHideLabel
         />,
     ),

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -28,24 +28,24 @@ describe('TextField', () => {
         expect(textField.find('label').length).to.equal(0);
     });
 
-    it('always renders a label element if hasLabelAlways is true', () => {
-        const textField = shallow(<TextField label="foo" value="bar" hasLabelAlways />);
+    it('does render a label element if hasLabelOnFocus is true and value is undefined', () => {
+        const textField = shallow(<TextField label="foo" hasLabelOnFocus />);
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('does not render a label element if label provided put value is defined', () => {
-        const textField = shallow(<TextField label="test" value="example" />);
+    it('does not render a label element if hasLabelOnFocus is true and value is defined', () => {
+        const textField = shallow(<TextField label="foo" value="test" hasLabelOnFocus />);
         expect(textField.find('label').length).to.equal(0);
     });
 
-    it('renders a label element when there is value and input has focus', () => {
-        const textField = shallow(<TextField label="test" value="example" />);
+    it('renders a label element when there is value and textarea has focus', () => {
+        const textField = shallow(<TextField label="test" value="example" hasLabelOnFocus />);
         textField.find('input').simulate('focus');
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('renders a label element when there is value and TextField has mouse over', () => {
-        const textField = shallow(<TextField label="test" value="example" />);
+    it('renders a label element when there is value and TextArea has mouse over', () => {
+        const textField = shallow(<TextField label="test" value="example" hasLabelOnFocus />);
         textField.simulate('mouseEnter');
         expect(textField.find('label').length).to.equal(1);
     });

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -38,13 +38,13 @@ describe('TextField', () => {
         expect(textField.find('label').length).to.equal(0);
     });
 
-    it('renders a label element when there is value and textarea has focus', () => {
+    it('renders a label element when there is value and input has focus', () => {
         const textField = shallow(<TextField label="test" value="example" autoHideLabel />);
         textField.find('input').simulate('focus');
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('renders a label element when there is value and TextArea has mouse over', () => {
+    it('renders a label element when there is value and TextField has mouse over', () => {
         const textField = shallow(<TextField label="test" value="example" autoHideLabel />);
         textField.simulate('mouseEnter');
         expect(textField.find('label').length).to.equal(1);

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -28,24 +28,24 @@ describe('TextField', () => {
         expect(textField.find('label').length).to.equal(0);
     });
 
-    it('does render a label element if hasLabelOnFocus is true and value is undefined', () => {
-        const textField = shallow(<TextField label="foo" hasLabelOnFocus />);
+    it('does render a label element if autoHideLabel is true and value is undefined', () => {
+        const textField = shallow(<TextField label="foo" autoHideLabel />);
         expect(textField.find('label').length).to.equal(1);
     });
 
-    it('does not render a label element if hasLabelOnFocus is true and value is defined', () => {
-        const textField = shallow(<TextField label="foo" value="test" hasLabelOnFocus />);
+    it('does not render a label element if autoHideLabel is true and value is defined', () => {
+        const textField = shallow(<TextField label="foo" value="test" autoHideLabel />);
         expect(textField.find('label').length).to.equal(0);
     });
 
     it('renders a label element when there is value and textarea has focus', () => {
-        const textField = shallow(<TextField label="test" value="example" hasLabelOnFocus />);
+        const textField = shallow(<TextField label="test" value="example" autoHideLabel />);
         textField.find('input').simulate('focus');
         expect(textField.find('label').length).to.equal(1);
     });
 
     it('renders a label element when there is value and TextArea has mouse over', () => {
-        const textField = shallow(<TextField label="test" value="example" hasLabelOnFocus />);
+        const textField = shallow(<TextField label="test" value="example" autoHideLabel />);
         textField.simulate('mouseEnter');
         expect(textField.find('label').length).to.equal(1);
     });


### PR DESCRIPTION
**Backwards Compatibility Implications**

- `hasLabelAlways` prop removed from TextField and TextArea

**New Features**

- `autoHideLabel` prop added to TextField and TextArea

**Bug Fixes**

_None_