### PR TITLE
Display TextField and TextArea error tooltip only if not valid

### DIFF
--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -185,7 +185,9 @@ class TextArea extends Component {
                     showTooltip={this.state.showTooltip}
                     tooltip={
                         <TooltipBox
-                            status={this.props.tooltipError ? ERROR : DEFAULT}
+                            status={this.props.tooltipError && this.props.isValid === false ?
+                                ERROR :
+                                DEFAULT}
                         >
                             {tooltip}
                         </TooltipBox>

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -216,6 +216,7 @@ class TextArea extends Component {
             null;
         /* eslint-enable */
         const showPlaceholder = (!this.props.label || this.state.hasFocus);
+        const tooltipError = this.props.isValid === false ? this.props.tooltipError : null;
         return (
             <div
                 className={cx(
@@ -261,7 +262,7 @@ class TextArea extends Component {
                             rows={this.props.rows}
                             value={this.state.value}
                         />,
-                        this.props.tooltipError || this.props.tooltipHint,
+                        tooltipError || this.props.tooltipHint,
                     )}
                     {requiredIconAndTooltip(
                         this.props.isRequired && !this.props.label,

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -117,7 +117,11 @@ stories.add(
 stories.add(
     'Tooltips',
     storyWrapper(
-        'tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.',
+        `
+tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.
+
+_NB: tooltipError will ONLY be displayed if isValid is false._
+`,
         <TextArea
             label="Input with a tooltip"
             isValid={false}

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -120,12 +120,20 @@ stories.add(
         'tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.',
         <TextArea
             label="Input with a tooltip"
+            isValid={false}
             tooltipHint="My Example Hint"
             tooltipError="My Example Error"
         />,
         <div>
-            <TextArea label="Input with an error" tooltipError="My Example Error" />
-            <TextArea label="Input with a hint" tooltipHint="My Example Hint" />
+            <TextArea
+                label="Input with an error"
+                isValid={false}
+                tooltipError="My Example Error"
+            />
+            <TextArea
+                label="Input with a hint"
+                tooltipHint="My Example Hint"
+            />
         </div>,
     ),
 );

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -222,9 +222,14 @@ describe('TextArea', () => {
         expect(textArea).to.have.className('uir-text-area--invalid');
     });
 
-    it('wraps textarea in a tooltip if tooltipError is given', () => {
-        const textArea = shallow(<TextArea tooltipError="error" />);
+    it('wraps textarea in a tooltip if tooltipError is given and isValid is false', () => {
+        const textArea = shallow(<TextArea isValid={false} tooltipError="error" />);
         expect(textArea.find(Tooltip).length).to.equal(1);
+    });
+
+    it('does not wrap textarea in a tooltip if tooltipError is given and isValid is true', () => {
+        const textArea = shallow(<TextArea isValid tooltipError="error" />);
+        expect(textArea.find(Tooltip).length).to.equal(0);
     });
 
     it('wraps textarea in a tooltip if tooltipHint is given', () => {

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -254,6 +254,7 @@ class TextField extends Component {
                 </Button>
             ) :
             null;
+        const tooltipError = this.props.isValid === false ? this.props.tooltipError : null;
         return (
             <div
                 className={cx(
@@ -304,7 +305,7 @@ class TextField extends Component {
                             type={this.props.type}
                             value={this.state.value}
                         />,
-                        this.props.tooltipError || this.props.tooltipHint,
+                        tooltipError || this.props.tooltipHint,
                     )}
                     {requiredIconAndTooltip(
                         this.props.isRequired && !this.props.label,

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -198,7 +198,9 @@ class TextField extends Component {
                     showTooltip={this.state.showTooltip}
                     tooltip={
                         <TooltipBox
-                            status={this.props.tooltipError ? ERROR : DEFAULT}
+                            status={this.props.tooltipError && this.props.isValid === false ?
+                                ERROR :
+                                DEFAULT}
                         >
                             {tooltip}
                         </TooltipBox>

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -158,7 +158,11 @@ stories.add(
 stories.add(
     'Tooltips',
     storyWrapper(
-        'tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.',
+        `
+tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.
+
+_NB: tooltipError will ONLY be displayed if isValid is false._
+`,
         <TextField
             label="Input with a tooltip"
             isValid={false}

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -161,18 +161,25 @@ stories.add(
         'tooltipHint and tooltipError allow you to display tooltips to users on input focus. Error takes precedence over hint.',
         <TextField
             label="Input with a tooltip"
+            isValid={false}
             tooltipHint="My Example Hint"
             tooltipError="My Example Error"
         />,
         <div>
-            <TextField label="Input with an error" tooltipError="My Example Error" />
-            <TextField label="Input with a hint" tooltipHint="My Example Hint" />
+            <TextField
+                label="Input with an error"
+                isValid={false}
+                tooltipError="My Example Error"
+            />
+            <TextField
+                label="Input with a hint"
+                tooltipHint="My Example Hint"
+            />
             <br />
             <TextField
-                placeholder="Required field"
+                label="Required field"
                 tooltipHint="My Example Hint"
                 isRequired
-                isFullWidth
             />
         </div>,
     ),

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -230,9 +230,14 @@ describe('TextField', () => {
         expect(textField).to.have.className('uir-text-field--invalid');
     });
 
-    it('wraps input in a tooltip if tooltipError is given', () => {
-        const textField = shallow(<TextField tooltipError="error" />);
+    it('wraps input in a tooltip if tooltipError is given and isValid is false', () => {
+        const textField = shallow(<TextField isValid={false} tooltipError="error" />);
         expect(textField.find(Tooltip).length).to.equal(1);
+    });
+
+    it('does not wrap input in a tooltip if tooltipError is given and isValid is true', () => {
+        const textField = shallow(<TextField isValid tooltipError="error" />);
+        expect(textField.find(Tooltip).length).to.equal(0);
     });
 
     it('wraps input in a tooltip if tooltipHint is given', () => {

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -246,7 +246,7 @@ describe('TextField', () => {
     });
 
     it('gives precedence to tooltipError over tooltipHint', () => {
-        const textField = mount(<TextField tooltipHint="hint" tooltipError="error" />);
+        const textField = mount(<TextField isValid={false} tooltipHint="hint" tooltipError="error" />);
         textField.find('input').simulate('focus');
         expect(textField.find(TooltipBox).prop('status')).to.equal(TooltipBoxStatus.ERROR);
     });


### PR DESCRIPTION
**Backwards Compatibility Implications**

- `isValid` and `errorTooltip` are no longer mutually exclusive, however, their functions do not change.

**New Features**

_None_

**Bug Fixes**

- `errorTooltip` will now **only** display if `isValid` is false.