### PR TITLE
Remove TextField icon spans when not in use

### DIFF
--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -242,16 +242,22 @@ class TextField extends Component {
             this.props.variant === TextFieldVariant.TITLE
         );
         const icon = this.props.icon ?
-            this.props.icon :
+            (
+                <span className="uir-text-field-left-icon">
+                    {this.props.icon}
+                </span>
+            ) :
             null;
         const clearIcon = this.props.isClearable && this.state.value ?
             (
-                <Button
-                    onClick={this.handleClearIconClick}
-                    variant={ButtonVariant.CLEAR}
-                >
-                    <IconClear />
-                </Button>
+                <span className="uir-text-field-right-icon">
+                    <Button
+                        onClick={this.handleClearIconClick}
+                        variant={ButtonVariant.CLEAR}
+                    >
+                        <IconClear />
+                    </Button>
+                </span>
             ) :
             null;
         return (
@@ -277,9 +283,7 @@ class TextField extends Component {
                 onMouseLeave={this.handleMouseLeave}
                 style={this.props.style}
             >
-                <span className="uir-text-field-left-icon">
-                    {icon}
-                </span>
+                {icon}
                 <div className="uir-text-field-inner">
                     <div className="uir-text-field-label-wrapper">
                         {label}
@@ -311,9 +315,7 @@ class TextField extends Component {
                         this.props.tooltipRequired,
                     )}
                 </div>
-                <span className="uir-text-field-right-icon">
-                    {clearIcon}
-                </span>
+                {clearIcon}
             </div>
         );
     }


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

- Previously the layout spans for the TextField icons would stay in the DOM even if no icon was being displayed.  This fixes that small bug and removes the spans if they are not in use.