### PR TITLE
Fix to allow TextField and TextArea value to be updated via props

### DIFF
--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -97,6 +97,12 @@ class TextArea extends Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (this.props.value !== nextProps.value) {
+            this.setState({ value: nextProps.value });
+        }
+    }
+
     handleMouseEnter = () => {
         this.setState({ hasMouseOver: true });
     }

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -119,6 +119,23 @@ describe('TextArea', () => {
         expect(textArea.find('textarea').prop('value')).to.equal(exampleValue);
     });
 
+    it('updates internal value when external prop changes', () => {
+        const textField = shallow(<TextArea value="foo" />);
+        expect(textField.state('value')).to.equal('foo');
+        textField.setProps({ value: 'bar' });
+        expect(textField.state('value')).to.equal('bar');
+    });
+
+    it('state does not change when prop value is the same', () => {
+        const textField = mount(<TextArea value="foo" />);
+        const instance = textField.instance();
+        const mock = sinon.mock(instance);
+        const expectation = mock.expects('setState');
+        textField.setProps({ name: 'bar' });
+        expect(expectation).to.not.be.called();
+        mock.restore();
+    });
+
     it('updates the component state when changing the textarea value', () => {
         const textArea = shallow(<TextArea />);
         const instance = textArea.instance();

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -102,6 +102,12 @@ class TextField extends Component {
         this.uid = `text-field-${lastInstanceId}`;
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (this.props.value !== nextProps.value) {
+            this.setState({ value: nextProps.value });
+        }
+    }
+
     handleMouseEnter = () => {
         this.setState({ hasMouseOver: true });
     }

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -1,18 +1,41 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import storyWrapper from '../../storybook-addons/storyWrapper';
 import TextField from './TextField';
+import Button from '../Button/Button';
 import { TextFieldVariant } from './TextFieldEnums';
 import IconSearch from '../Icon/IconSearch';
 import IconNotification from '../Icon/IconNotification';
 
 const stories = storiesOf('Fields.TextField', module);
 
+class ChangeValueDemoComp extends Component {
+    state = {
+        value: 'I am the default...',
+    }
+
+    handleClick = () => {
+        this.setState({
+            value: 'I have changed!',
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                <TextField label="Text field label" value={this.state.value} />
+                <Button onClick={this.handleClick}>Click to Change</Button>
+            </div>
+        );
+    }
+}
+
 stories.add(
     'Overview',
     storyWrapper(
         'TextField is a text input field.',
         <TextField label="Text field label" />,
+        <ChangeValueDemoComp />,
     ),
 );
 

--- a/src/components/Fields/TextField.test-int.js
+++ b/src/components/Fields/TextField.test-int.js
@@ -23,6 +23,6 @@ Scenario('Storybook Documentation', (I) => {
 
 Scenario('TextField', (I) => {
     I.searchWithinIframe(KIND, 'Overview', () => {
-        I.seeNumberOfElements('.uir-text-field', 1);
+        I.seeNumberOfElements('.uir-text-field', 2);
     });
 });

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -119,6 +119,23 @@ describe('TextField', () => {
         expect(textField.find('input').prop('value')).to.equal(exampleValue);
     });
 
+    it('updates internal value when external prop changes', () => {
+        const textField = shallow(<TextField value="foo" />);
+        expect(textField.state('value')).to.equal('foo');
+        textField.setProps({ value: 'bar' });
+        expect(textField.state('value')).to.equal('bar');
+    });
+
+    it('state does not change when prop value is the same', () => {
+        const textField = mount(<TextField value="foo" />);
+        const instance = textField.instance();
+        const mock = sinon.mock(instance);
+        const expectation = mock.expects('setState');
+        textField.setProps({ name: 'bar' });
+        expect(expectation).to.not.be.called();
+        mock.restore();
+    });
+
     it('updates the component state when changing the input value', () => {
         const textField = mount(<TextField />);
         const instance = textField.instance();


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

- Can now update TextField and TextValue value via props