### PR TITLE
Button resizes to contain confirmation text

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -67,6 +67,39 @@ class Button extends Component {
         clearTimeout(this.confirmedTimeout);
     }
 
+    getConfirmationPane() {
+        return (
+            <span
+                aria-hidden={!this.state.confirming && !this.state.confirmed}
+            >
+                {this.getConfirmationTextPlaceholder()}
+                <span
+                    className={cx(
+                        'uir-button',
+                        'uir-button-confirmation',
+                        {
+                            'uir-button-confirmation--confirming': this.state.confirming,
+                            'uir-button-confirmation--confirmed': this.state.confirmed,
+                        },
+                    )}
+                >
+                    {this.state.confirmed ? this.props.confirmedText : null}
+                    {this.state.confirming ? this.props.confirmText : null}
+                </span>
+            </span>
+        );
+    }
+
+    // Outputs confirm and confirmed strings in order to reserve appropriate horizontal space.
+    // This is for width calculation only, the text is hidden from all users.
+    getConfirmationTextPlaceholder() {
+        return (
+            <span className="uir-button-confirmation-placeholder" aria-hidden="true">
+                {`${this.props.confirmText} \n ${this.props.confirmedText}`}
+            </span>
+        );
+    }
+
     handleBlur = () => {
         if (this.state.confirming) {
             this.setState({
@@ -138,28 +171,12 @@ class Button extends Component {
                 ref={this.handleRef}
                 tabIndex={this.props.tabIndex}
             >
-                {this.props.iconPosition === ButtonIconPosition.LEFT ? this.props.icon : null }
+                {this.props.iconPosition === ButtonIconPosition.LEFT ? this.props.icon : null}
                 <span className="uir-button-content">
                     {this.props.children}
                 </span>
-                {this.props.iconPosition === ButtonIconPosition.RIGHT ? this.props.icon : null }
-                {this.props.hasConfirm ?
-                    <span
-                        aria-hidden={!this.state.confirming && !this.state.confirmed}
-                        className={cx(
-                            'uir-button',
-                            'uir-button-confirmation',
-                            {
-                                'uir-button-confirmation--confirming': this.state.confirming,
-                                'uir-button-confirmation--confirmed': this.state.confirmed,
-                            },
-                        )}
-                    >
-                        {this.state.confirmed ? this.props.confirmedText : null}
-                        {this.state.confirming ? this.props.confirmText : null}
-                    </span>
-                    : null
-                }
+                {this.props.iconPosition === ButtonIconPosition.RIGHT ? this.props.icon : null}
+                {this.props.hasConfirm ? this.getConfirmationPane() : null}
             </button>
         );
     }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -75,7 +75,6 @@ class Button extends Component {
                 {this.getConfirmationTextPlaceholder()}
                 <span
                     className={cx(
-                        'uir-button',
                         'uir-button-confirmation',
                         {
                             'uir-button-confirmation--confirming': this.state.confirming,

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -220,5 +220,16 @@
         &--confirmed {
             display: block;
         }
+
+        // Placeholder sets Button width based on the longest string.
+        // It's hidden form screenreaders using aria-hidden attribute.
+        // Hide it from sighted users using CSS.
+        &-placeholder {
+            display: block;
+            height: 0;
+            overflow: hidden;
+            white-space: pre;
+            visibility: hidden;
+        }
     }
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -21,12 +21,14 @@
     $button-icon-width: $base-font-size + 4 !default;
     $button-icon-height: $base-font-size + 4 !default;
 
+    $_button-padding: 9px 18px;
+
     position: relative;
     box-sizing: border-box;
     display: inline-block;
     min-width: 50px;
     min-height: 1em;
-    padding: 9px 18px;
+    padding: $_button-padding;
     margin: 8px 8px 8px 0;
     overflow: hidden;
     font-family: $button-font-family;
@@ -192,6 +194,7 @@
         bottom: 0;
         left: 0;
         display: none;
+        padding: $_button-padding;
         margin: 0;
         overflow: visible;
         line-height: 1.5;

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -138,6 +138,7 @@ stories.add(
         `
 Add an extra confirmation step with <code>hasConfirm</code>
 Use <code>confirmText</code> and <code>confirmedText</code> to customise the strings.
+Please note that the Button will resize to contain the longest string.
         `,
         <Button
             hasConfirm
@@ -148,7 +149,7 @@ Use <code>confirmText</code> and <code>confirmedText</code> to customise the str
         <div>
             <Button
                 hasConfirm
-                confirmText="Sure?"
+                confirmText="Are you absolutely sure?"
                 confirmedText="OK!"
                 onClick={() => { console.log('Confirmed!'); }}  // eslint-disable-line
             >

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -104,7 +104,7 @@ describe('Button', () => {
             const confirmation = wrapper.find('.uir-button-confirmation');
 
             wrapper.simulate('click');
-            confirmation.simulate('click');
+            wrapper.simulate('click');
 
             expect(confirmation).not.to.have.className('uir-button-confirmation--confirming');
         });
@@ -114,7 +114,7 @@ describe('Button', () => {
             const confirmation = wrapper.find('.uir-button-confirmation');
 
             wrapper.simulate('click');
-            confirmation.simulate('click');
+            wrapper.simulate('click');
 
             expect(confirmation).to.have.className('uir-button-confirmation--confirmed');
         });
@@ -124,7 +124,7 @@ describe('Button', () => {
             const confirmation = wrapper.find('.uir-button-confirmation');
 
             wrapper.simulate('click');
-            confirmation.simulate('click');
+            wrapper.simulate('click');
 
             setTimeout(() => {
                 expect(confirmation).not.to.have.className('uir-button-confirmation--confirmed');
@@ -134,12 +134,11 @@ describe('Button', () => {
 
         it('does not call setState after unmount', (done) => {
             const wrapper = mount(defaultConfirmButton);
-            const confirmation = wrapper.find('.uir-button-confirmation');
 
             sandbox.stub(console, 'error');
 
             wrapper.simulate('click');
-            confirmation.simulate('click');
+            wrapper.simulate('click');
             wrapper.unmount();
 
             setTimeout(() => {
@@ -151,52 +150,80 @@ describe('Button', () => {
             }, 1100);
         });
 
+        it('does not call onClick when not confirmed', () => {
+            const onClick = sandbox.spy();
+            const wrapper = mount((
+                <Button hasConfirm onClick={onClick}>Foo</Button>
+            ));
+
+            wrapper.simulate('click');
+            expect(onClick).not.to.have.been.called();
+        });
+
         it('calls onClick when confirmed', () => {
             const onClick = sandbox.spy();
             const wrapper = mount((
                 <Button hasConfirm onClick={onClick}>Foo</Button>
             ));
-            const confirmation = wrapper.find('.uir-button-confirmation');
 
+            // First click to show the confirmation
             wrapper.simulate('click');
-            confirmation.simulate('click');
+            // And confirm
+            wrapper.simulate('click');
             expect(onClick).to.have.been.calledOnce();
         });
 
         describe('confirmText', () => {
+            it('does not show default text before click', () => {
+                const wrapper = mount(defaultConfirmButton);
+                const confirmation = wrapper.find('.uir-button-confirmation');
+
+                expect(confirmation).not.to.contain.text('Confirm?');
+            });
+
             it('shows default text', () => {
                 const wrapper = mount(defaultConfirmButton);
+                const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                expect(wrapper).to.contain.text('Confirm?');
+                expect(confirmation).to.contain.text('Confirm?');
             });
 
             it('shows custom text', () => {
                 const wrapper = mount((
                     <Button hasConfirm confirmText="BarBaz?" onClick={() => {}}>Foo</Button>
                 ));
+                const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                expect(wrapper).to.contain.text('BarBaz?');
+                expect(confirmation).to.contain.text('BarBaz?');
             });
 
             it('does not show default confirmed text', () => {
                 const wrapper = mount(defaultConfirmButton);
+                const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                expect(wrapper).not.to.contain.text('Cool!');
+                expect(confirmation).not.to.contain.text('Cool!');
             });
         });
 
         describe('confirmedText', () => {
+            it('does not show default text before click', () => {
+                const wrapper = mount(defaultConfirmButton);
+                const confirmation = wrapper.find('.uir-button-confirmation');
+
+                expect(confirmation).not.to.contain.text('Cool!');
+            });
+
             it('shows default text', () => {
                 const wrapper = mount(defaultConfirmButton);
                 const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                confirmation.simulate('click');
+                wrapper.simulate('click');
 
-                expect(wrapper).to.contain.text('Cool!');
+                expect(confirmation).to.contain.text('Cool!');
             });
 
             it('shows custom text', () => {
@@ -206,9 +233,9 @@ describe('Button', () => {
                 const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                confirmation.simulate('click');
+                wrapper.simulate('click');
 
-                expect(wrapper).to.contain.text('BarBaz!');
+                expect(confirmation).to.contain.text('BarBaz!');
             });
 
             it('does not show default confirming text', () => {
@@ -216,9 +243,9 @@ describe('Button', () => {
                 const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                confirmation.simulate('click');
+                wrapper.simulate('click');
 
-                expect(wrapper).not.to.contain.text('Confirm?');
+                expect(confirmation).not.to.contain.text('Confirm?');
             });
         });
 
@@ -231,9 +258,9 @@ describe('Button', () => {
 
                 expect(confirmation).to.have.className('uir-button-confirmation--confirming');
 
-                confirmation.simulate('blur');
+                wrapper.simulate('blur');
 
-                expect(wrapper).not.to.contain.text('Confirm?');
+                expect(confirmation).not.to.contain.text('Confirm?');
                 expect(confirmation).not.to.have.className('uir-button-confirmation--confirming');
             });
 
@@ -243,13 +270,13 @@ describe('Button', () => {
                 const confirmation = wrapper.find('.uir-button-confirmation');
 
                 wrapper.simulate('click');
-                confirmation.simulate('click');
+                wrapper.simulate('click');
 
                 expect(confirmation).not.to.have.className('uir-button-confirmation--confirming');
 
-                confirmation.simulate('blur');
+                wrapper.simulate('blur');
 
-                expect(wrapper).not.to.contain.text('Confirm?');
+                expect(confirmation).not.to.contain.text('Confirm?');
                 expect(confirmation).not.to.have.className('uir-button-confirmation--confirming');
             });
         });


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

- Button now automatically resizes to contain long confirmation text and prevent overflow and misalignment
