### PR TITLE
Clear button triggers input change

### DIFF
--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -175,12 +175,12 @@ class TextField extends Component {
         }
     }
 
-    handleClearIconClick = () => {
-        this.setState({ value: '' }, () => {
-            if (this.inputRef) {
-                this.inputRef.focus();
-            }
-        });
+    handleClearIconClick = (event) => {
+        if (this.inputRef) {
+            this.inputRef.value = '';
+            this.inputRef.focus();
+            this.handleInputChange(event);
+        }
     }
 
     /**

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -254,17 +254,29 @@ stories.add(
 stories.add(
     'Clearable',
     storyWrapper(
-        'isClearable displays an icon that allows the user to clear a field.',
+        `
+isClearable displays an icon that allows the user to clear a field.
+
+_NB: when the clear icon is clicked, the input will trigger an onChange event_
+        `,
         <TextField
             label="Clearable input"
             value="clear me"
             isClearable
         />,
-        <TextField
-            label="Clearable required input"
-            isClearable
-            isRequired
-        />,
+        <div>
+            <TextField
+                label="Clearable required input"
+                isClearable
+                isRequired
+            />
+            <TextField
+                label="Console log on clear"
+                value="clear me"
+                isClearable
+                onChange={(value) => { console.log(value); }} // eslint-disable-line no-console
+            />
+        </div>,
     ),
 );
 

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -290,9 +290,15 @@ describe('TextField', () => {
     });
 
     it('clears value when clear icon is clicked', () => {
-        const textField = shallow(<TextField value="an example value" isClearable />);
+        const textField = mount(<TextField value="an example value" isClearable />);
         textField.find(Button).simulate('click');
         expect(textField.state('value')).to.equal('');
+    });
+
+    it('clear does not change value if input is not mounted and has no reference', () => {
+        const textField = shallow(<TextField value="foo" isClearable />);
+        textField.find(Button).simulate('click');
+        expect(textField.state('value')).to.equal('foo');
     });
 
     it('input regains focus after clear icon is clicked', () => {


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

- clicking the clear icon will now trigger the input change event

**Bug Fixes**

_None_