### PR TITLE
TextField accepts zero as a valid input

### DIFF
--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -311,7 +311,7 @@ class TextField extends Component {
                         'uir-text-field--full-width': this.props.isFullWidth,
                         'uir-text-field--has-left-icon': this.props.icon,
                         'uir-text-field--has-right-icon': this.props.isRequired || this.props.isClearable,
-                        'uir-text-field--has-value': this.state.value,
+                        'uir-text-field--has-value': `${this.state.value}`,
                         'uir-text-field--invalid': this.props.isValid === false,
                         'uir-text-field--readonly': this.props.isReadOnly,
                         'uir-text-field--title': this.props.variant === TextFieldVariant.TITLE,

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -97,6 +97,19 @@ stories.add(
             placeholder="your placeholder here"
             value="Hello, Friend"
         />,
+        <div>
+            <TextField
+                label="Number Zero"
+                placeholder="your placeholder here"
+                value={0}
+            />
+            <TextField
+                label="Empty String"
+                placeholder="your placeholder here"
+                value=""
+            />
+        </div>
+        ,
     ),
 );
 

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -356,4 +356,19 @@ describe('TextField', () => {
         const textField = shallow(<TextField name={exampleName} />);
         expect(textField.find('input').prop('name')).to.equal(exampleName);
     });
+
+    it('adds --has-value when value is not null', () => {
+        const textField = shallow(<TextField value="test" />);
+        expect(textField.hasClass('uir-text-field--has-value')).to.equal(true);
+    });
+
+    it('adds --has-value when value is falsy but not null', () => {
+        const textField = shallow(<TextField value={0} />);
+        expect(textField.hasClass('uir-text-field--has-value')).to.equal(true);
+    });
+
+    it('does not add --has-value when value isnull', () => {
+        const textField = shallow(<TextField />);
+        expect(textField.hasClass('uir-text-field--has-value')).to.not.equal(true);
+    });
 });

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -374,7 +374,7 @@ describe('TextField', () => {
         expect(textField.hasClass('uir-text-field--has-value')).to.equal(true);
     });
 
-    it('does not add --has-value when value isnull', () => {
+    it('does not add --has-value when value is undefined', () => {
         const textField = shallow(<TextField />);
         expect(textField.hasClass('uir-text-field--has-value')).to.not.equal(true);
     });


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

_None_

**Bug Fixes**

- allow zero to activate TextField and move label