### PR TITLE
Add prefix prop to TextField

### DIFF
--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -21,7 +21,7 @@ const propTypes = {
         AvatarSize.LG,
     ]),
     src: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     tabIndex: PropTypes.number,
 };
 

--- a/src/components/Avatar/AvatarCard.js
+++ b/src/components/Avatar/AvatarCard.js
@@ -9,7 +9,7 @@ const propTypes = {
     className: PropTypes.string,
     jobRole: PropTypes.string,
     name: PropTypes.string.isRequired,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     team: PropTypes.string,
 };
 

--- a/src/components/Avatar/AvatarTitle.js
+++ b/src/components/Avatar/AvatarTitle.js
@@ -15,7 +15,7 @@ const propTypes = {
         AvatarTitleSize.SM,
         AvatarTitleSize.LG,
     ]),
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -13,7 +13,10 @@ const propTypes = {
     confirmText: PropTypes.string,
     confirmedText: PropTypes.string,
     hasConfirm: PropTypes.bool,
-    icon: PropTypes.element,
+    icon: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.string,
+    ]),
     iconPosition: ListPropType([
         ButtonIconPosition.LEFT,
         ButtonIconPosition.RIGHT,

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import ElementOrStringPropType from '../../prop-types/element-or-string';
 import ListPropType from '../../prop-types/list';
 import StyleObjectPropType from '../../prop-types/style';
 import { ButtonIconPosition, ButtonType, ButtonVariant } from './ButtonEnums';
@@ -13,10 +14,7 @@ const propTypes = {
     confirmText: PropTypes.string,
     confirmedText: PropTypes.string,
     hasConfirm: PropTypes.bool,
-    icon: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    icon: ElementOrStringPropType,
     iconPosition: ListPropType([
         ButtonIconPosition.LEFT,
         ButtonIconPosition.RIGHT,
@@ -26,7 +24,7 @@ const propTypes = {
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     tabIndex: PropTypes.number,
     type: ListPropType([
         ButtonType.BUTTON,

--- a/src/components/Fields/DateField.js
+++ b/src/components/Fields/DateField.js
@@ -21,7 +21,7 @@ const propTypes = {
     onFocus: PropTypes.func,
     rangeFromValue: PropTypes.instanceOf(Date),
     rangeToValue: PropTypes.instanceOf(Date),
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     datePickerPosition: ListPropType([
         TooltipPosition.TOP_CENTER,
         TooltipPosition.TOP_LEFT,

--- a/src/components/Fields/DateFieldRange.js
+++ b/src/components/Fields/DateFieldRange.js
@@ -14,7 +14,7 @@ const propTypes = {
     onChange: PropTypes.func,
     rangeFromValue: PropTypes.instanceOf(Date),
     rangeToValue: PropTypes.instanceOf(Date),
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     toLabel: PropTypes.string,
 };
 

--- a/src/components/Fields/DateInlinePicker.js
+++ b/src/components/Fields/DateInlinePicker.js
@@ -8,7 +8,7 @@ import './DateInlinePicker.scss';
 const propTypes = {
     className: PropTypes.string,
     onChange: PropTypes.func,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import autosize from 'autosize';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import ElementOrStringPropType from '../../prop-types/element-or-string';
 import StyleObjectPropType from '../../prop-types/style';
 import Tooltip from '../Tooltip/Tooltip';
 import TooltipBox from '../Tooltip/TooltipBox';
@@ -30,19 +31,10 @@ const propTypes = {
     onKeyUp: PropTypes.func,
     placeholder: PropTypes.string,
     rows: PropTypes.number,
-    style: StyleObjectPropType(),
-    tooltipError: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
-    tooltipHint: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
-    tooltipRequired: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    style: StyleObjectPropType,
+    tooltipError: ElementOrStringPropType,
+    tooltipHint: ElementOrStringPropType,
+    tooltipRequired: ElementOrStringPropType,
     value: PropTypes.string,
 };
 

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -334,7 +334,7 @@ class TextField extends Component {
                         'uir-text-field--has-left-icon': this.props.icon,
                         'uir-text-field--has-prefix': this.props.prefix,
                         'uir-text-field--has-right-icon': this.props.isRequired || this.props.isClearable,
-                        'uir-text-field--has-value': this.state.value,
+                        'uir-text-field--has-value': `${this.state.value}`,
                         'uir-text-field--invalid': this.props.isValid === false,
                         'uir-text-field--readonly': this.props.isReadOnly,
                         'uir-text-field--title': this.props.variant === TextFieldVariant.TITLE,

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -17,7 +17,10 @@ const propTypes = {
     autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
     componentRef: PropTypes.func,
-    icon: PropTypes.element,
+    icon: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.string,
+    ]),
     isClearable: PropTypes.bool,
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
@@ -36,6 +39,10 @@ const propTypes = {
     onKeyPress: PropTypes.func,
     onKeyUp: PropTypes.func,
     placeholder: PropTypes.string,
+    prefix: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.string,
+    ]),
     step: PropTypes.number,
     style: StyleObjectPropType(),
     tooltipError: PropTypes.oneOfType([
@@ -92,6 +99,7 @@ const defaultProps = {
     onKeyPress: null,
     onKeyUp: null,
     placeholder: null,
+    prefix: null,
     step: null,
     style: null,
     tooltipError: null,
@@ -275,6 +283,19 @@ class TextField extends Component {
             this.state.hasFocus ||
             this.props.variant === TextFieldVariant.TITLE
         );
+        const prefix = this.props.prefix && (this.state.hasFocus || this.state.value) ?
+            (
+                <span className="uir-text-field-prefix">
+                    <Button
+                        className="uir-text-field-prefix-wrapper"
+                        icon={this.props.prefix}
+                        onClick={this.handleIconClick}
+                        tabIndex={-1}
+                        variant={ButtonVariant.CLEAR}
+                    />
+                </span>
+            ) :
+            null;
         const icon = this.props.icon ?
             (
                 <span className="uir-text-field-left-icon">
@@ -311,8 +332,9 @@ class TextField extends Component {
                         'uir-text-field--focus': this.state.hasFocus,
                         'uir-text-field--full-width': this.props.isFullWidth,
                         'uir-text-field--has-left-icon': this.props.icon,
+                        'uir-text-field--has-prefix': this.props.prefix,
                         'uir-text-field--has-right-icon': this.props.isRequired || this.props.isClearable,
-                        'uir-text-field--has-value': `${this.state.value}`,
+                        'uir-text-field--has-value': this.state.value,
                         'uir-text-field--invalid': this.props.isValid === false,
                         'uir-text-field--readonly': this.props.isReadOnly,
                         'uir-text-field--title': this.props.variant === TextFieldVariant.TITLE,
@@ -324,7 +346,7 @@ class TextField extends Component {
                 onMouseLeave={this.handleMouseLeave}
                 style={this.props.style}
             >
-                {icon}
+                {prefix || icon}
                 <div className="uir-text-field-inner">
                     <div className="uir-text-field-label-wrapper">
                         {label}

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -52,7 +52,10 @@ const propTypes = {
     ]),
     tooltipRequired: ElementOrStringPropType,
     type: PropTypes.string,
-    value: ElementOrStringPropType,
+    value: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+    ]),
     variant: ListPropType([
         TextFieldVariant.DEFAULT,
         TextFieldVariant.TITLE,
@@ -279,7 +282,7 @@ class TextField extends Component {
                 </span>
             ) :
             null;
-        const icon = this.props.icon ?
+        const icon = this.props.prefix === null && this.props.icon ?
             (
                 <span className="uir-text-field-left-icon">
                     <Button

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import StyleObjectPropType from '../../prop-types/style';
+import ElementOrStringPropType from '../../prop-types/element-or-string';
 import ListPropType from '../../prop-types/list';
+import StyleObjectPropType from '../../prop-types/style';
 import Tooltip from '../Tooltip/Tooltip';
 import TooltipBox from '../Tooltip/TooltipBox';
 import { TooltipBoxStatus, TooltipPosition } from '../Tooltip/TooltipEnums';
@@ -17,10 +18,7 @@ const propTypes = {
     autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
     componentRef: PropTypes.func,
-    icon: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    icon: ElementOrStringPropType,
     isClearable: PropTypes.bool,
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
@@ -39,20 +37,11 @@ const propTypes = {
     onKeyPress: PropTypes.func,
     onKeyUp: PropTypes.func,
     placeholder: PropTypes.string,
-    prefix: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    prefix: ElementOrStringPropType,
     step: PropTypes.number,
-    style: StyleObjectPropType(),
-    tooltipError: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
-    tooltipHint: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    style: StyleObjectPropType,
+    tooltipError: ElementOrStringPropType,
+    tooltipHint: ElementOrStringPropType,
     tooltipPosition: ListPropType([
         TooltipPosition.TOP_CENTER,
         TooltipPosition.TOP_LEFT,
@@ -61,15 +50,9 @@ const propTypes = {
         TooltipPosition.BOTTOM_RIGHT,
         TooltipPosition.BOTTOM_LEFT,
     ]),
-    tooltipRequired: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]),
+    tooltipRequired: ElementOrStringPropType,
     type: PropTypes.string,
-    value: PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-    ]),
+    value: ElementOrStringPropType,
     variant: ListPropType([
         TextFieldVariant.DEFAULT,
         TextFieldVariant.TITLE,

--- a/src/components/Fields/TextField.scss
+++ b/src/components/Fields/TextField.scss
@@ -146,6 +146,10 @@ $textFieldLabelColor: $charcoal !default;
         margin-left: 5px;
     }
 
+    .uir-text-field-prefix {
+        z-index: 10;
+    }
+
     .uir-text-field-prefix,
     .uir-text-field-left-icon,
     .uir-text-field-right-icon {

--- a/src/components/Fields/TextField.scss
+++ b/src/components/Fields/TextField.scss
@@ -39,12 +39,25 @@ $textFieldLabelColor: $charcoal !default;
         }
     }
 
+    &--has-left-icon {
+        padding-left: 20px;
+    }
+
     &--has-right-icon {
         padding-right: 20px;
     }
 
-    &--has-left-icon {
+    &--has-prefix {
         padding-left: 20px;
+
+        .uir-text-field-inner {
+            left: -20px;
+        }
+
+        .uir-text-field-input {
+            position: relative;
+            left: 20px;
+        }
     }
 
     &--disabled:after {
@@ -133,6 +146,7 @@ $textFieldLabelColor: $charcoal !default;
         margin-left: 5px;
     }
 
+    .uir-text-field-prefix,
     .uir-text-field-left-icon,
     .uir-text-field-right-icon {
         position: absolute;
@@ -140,6 +154,7 @@ $textFieldLabelColor: $charcoal !default;
         line-height: 1em;
     }
 
+    .uir-text-field-prefix,
     .uir-text-field-left-icon {
         left: 2px;
     }
@@ -152,6 +167,7 @@ $textFieldLabelColor: $charcoal !default;
         }
     }
 
+    .uir-button.uir-text-field-prefix-wrapper,
     .uir-button.uir-text-field-icon-wrapper {
         min-width: 16px;
         padding: 0;
@@ -165,5 +181,9 @@ $textFieldLabelColor: $charcoal !default;
                 fill: $charcoal;
             }
         }
+    }
+
+    .uir-button.uir-text-field-prefix-wrapper {
+        text-align: left;
     }
 }

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -326,8 +326,20 @@ _NB: when the clear icon is clicked, the input will trigger an \`onChange\` even
 stories.add(
     'Icon',
     storyWrapper(
-        '`icon` prop allows you to display an icon on the left of the input field.',
+        'icon` prop allows you to display an icon on the left of the input field.',
         <TextField placeholder="search" icon={<IconSearch />} />,
-        <TextField label="Full width with icon" isFullWidth icon={<IconNotification />} />,
+        <div>
+            <TextField label="Search" icon={<IconSearch />} />
+            <TextField label="Emoji" icon="😺" />
+            <TextField label="Full width with icon" isFullWidth icon={<IconNotification />} />
+        </div>,
+    ),
+);
+
+stories.add(
+    'Prefix',
+    storyWrapper(
+        '`prefix` prop allows you to display an alternative to an icon on focus only, the prefix appears tight the left of the value and is good for showing currency.',
+        <TextField label="Currency" prefix="£" />,
     ),
 );

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -339,7 +339,11 @@ stories.add(
 stories.add(
     'Prefix',
     storyWrapper(
-        '`prefix` prop allows you to display an alternative to an icon on focus only, the prefix appears tight the left of the value and is good for showing currency.',
+        `
+\`prefix\` prop allows you to display an alternative to an icon on focus only, the prefix appears tight the left of the value and is good for showing currency.
+
+_NB: if you add a prefix and an icon, only the prefix will be displayed_
+        `,
         <TextField label="Currency" prefix="£" />,
     ),
 );

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -340,7 +340,7 @@ stories.add(
     'Prefix',
     storyWrapper(
         `
-\`prefix\` prop allows you to display an alternative to an icon on focus only, the prefix appears tight the left of the value and is good for showing currency.
+\`prefix\` prop allows you to display an alternative to an icon on focus only, the prefix appears to the left of the value and is good for showing currency.
 
 _NB: if you add a prefix and an icon, only the prefix will be displayed_
         `,

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -308,6 +308,11 @@ describe('TextField', () => {
         expect(textField.find(Button).length).to.equal(1);
     });
 
+    it('only displays prefix if prefix and icon are set', () => {
+        const textField = mount(<TextField icon={<IconSearch />} prefix="£" value="test" />);
+        expect(textField.find(Button).first().text()).to.equal('£');
+    });
+
     it('gives focus to input when prefix is clicked', () => {
         const textField = mount(<TextField
             onFocus={event => expect(event).to.have.property('value')}

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -297,6 +297,33 @@ describe('TextField', () => {
         expect(textField.find(Tooltip).length).to.equal(1);
     });
 
+    it('displays a prefix if value present', () => {
+        const textField = shallow(<TextField prefix="£" value="test" />);
+        expect(textField.find(Button).length).to.equal(1);
+    });
+
+    it('displays a prefix if input has focus', () => {
+        const textField = shallow(<TextField prefix="£" />);
+        textField.setState({ hasFocus: true });
+        expect(textField.find(Button).length).to.equal(1);
+    });
+
+    it('gives focus to input when prefix is clicked', () => {
+        const textField = mount(<TextField
+            onFocus={event => expect(event).to.have.property('value')}
+            prefix="£"
+            value="test"
+        />);
+        textField.find(Button).simulate('click');
+    });
+
+    it('does not clear value when prefix is clicked', () => {
+        const mockValue = 'test me';
+        const textField = mount(<TextField prefix="£" value={mockValue} />);
+        textField.find(Button).simulate('click');
+        expect(textField.state('value')).to.equal(mockValue);
+    });
+
     it('gives focus to input when left icon is clicked', () => {
         const textField = mount(<TextField
             icon={<IconSearch />}

--- a/src/components/Icon/IconArrow.js
+++ b/src/components/Icon/IconArrow.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconArrowLongRight.js
+++ b/src/components/Icon/IconArrowLongRight.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconClear.js
+++ b/src/components/Icon/IconClear.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconMore.js
+++ b/src/components/Icon/IconMore.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconNotification.js
+++ b/src/components/Icon/IconNotification.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconRequired.js
+++ b/src/components/Icon/IconRequired.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Icon/IconSearch.js
+++ b/src/components/Icon/IconSearch.js
@@ -8,7 +8,7 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -13,7 +13,7 @@ const propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     selectedIndex: PropTypes.number,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     tabsVisible: PropTypes.number,
 };
 

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import ElementOrStringPropType from '../../prop-types/element-or-string';
 import ListPropType from '../../prop-types/list';
 import StyleObjectPropType from '../../prop-types/style';
 import TooltipBox from './TooltipBox';
@@ -19,12 +20,9 @@ const propTypes = {
         TooltipPosition.BOTTOM_LEFT,
     ]),
     showTooltip: PropTypes.bool,
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
     tabIndex: PropTypes.number,
-    tooltip: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]).isRequired,
+    tooltip: ElementOrStringPropType.isRequired,
 };
 
 const defaultProps = {

--- a/src/components/Tooltip/TooltipBox.js
+++ b/src/components/Tooltip/TooltipBox.js
@@ -1,23 +1,21 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import ElementOrStringPropType from '../../prop-types/element-or-string';
 import ListPropType from '../../prop-types/list';
 import StyleObjectPropType from '../../prop-types/style';
 import { TooltipBoxStatus } from './TooltipEnums';
 import './TooltipBox.scss';
 
 const propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.string,
-    ]).isRequired,
+    children: ElementOrStringPropType.isRequired,
     className: PropTypes.string,
     status: ListPropType([
         TooltipBoxStatus.DEFAULT,
         TooltipBoxStatus.SUCCESS,
         TooltipBoxStatus.ERROR,
     ]),
-    style: StyleObjectPropType(),
+    style: StyleObjectPropType,
 };
 
 const defaultProps = {

--- a/src/prop-types/element-or-string.js
+++ b/src/prop-types/element-or-string.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const elementOrString = PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+]);
+
+export default elementOrString;

--- a/src/prop-types/element-or-string.test.js
+++ b/src/prop-types/element-or-string.test.js
@@ -1,0 +1,73 @@
+/* global describe, it, expect, beforeEach, afterEach  */
+import sinon from 'sinon';
+import PropTypes from 'prop-types';
+import Button from '../components/Button/Button';
+import ElementOrStringPropType from './element-or-string';
+
+describe('Element or String Prop Type', () => {
+    describe('check prop types for validity', () => {
+        const sandbox = sinon.sandbox.create();
+
+        beforeEach(() => {
+            sandbox.stub(console, 'error');
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('invalid prop types throws error', () => {
+            const propTypes = {
+                test: ElementOrStringPropType,
+            };
+            const props = {
+                test: false,
+            };
+            PropTypes.checkPropTypes(
+                propTypes,
+                props,
+                'prop',
+                'testComponent',
+                null,
+            );
+            // eslint-disable-next-line no-console
+            expect(console.error).to.be.calledWithMatch('Invalid prop `test` supplied to `testComponent`');
+        });
+
+        it('valid prop type string does not throw an error', () => {
+            const propTypes = {
+                test: ElementOrStringPropType,
+            };
+            const props = {
+                test: 'test',
+            };
+            PropTypes.checkPropTypes(
+                propTypes,
+                props,
+                'prop',
+                'testComponent',
+                null,
+            );
+            // eslint-disable-next-line no-console
+            expect(console.error).to.not.be.called();
+        });
+
+        it('valid prop type element does not throw an error', () => {
+            const propTypes = {
+                test: ElementOrStringPropType,
+            };
+            const props = {
+                test: Button,
+            };
+            PropTypes.checkPropTypes(
+                propTypes,
+                props,
+                'prop',
+                'testComponent',
+                null,
+            );
+            // eslint-disable-next-line no-console
+            expect(console.error).to.not.be.called();
+        });
+    });
+});

--- a/src/prop-types/initials.test.js
+++ b/src/prop-types/initials.test.js
@@ -1,4 +1,4 @@
-/* global describe, expect, it */
+/* global describe, it, expect */
 import InitialsPropType from './initials';
 
 describe('Initials Prop Type', () => {

--- a/src/prop-types/style.js
+++ b/src/prop-types/style.js
@@ -1,15 +1,8 @@
 import PropTypes from 'prop-types';
 
-function createStyleObjectPropType() {
-    function style() {
-        return PropTypes.objectOf(PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.number,
-        ]));
-    }
-    return style;
-}
-
-const styleObjectPropType = createStyleObjectPropType();
+const styleObjectPropType = PropTypes.objectOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+]));
 
 export default styleObjectPropType;

--- a/src/prop-types/style.test.js
+++ b/src/prop-types/style.test.js
@@ -5,7 +5,7 @@ import StyleObjectPropType from './style';
 
 function validateRunner(value) {
     const types = {
-        style: StyleObjectPropType(),
+        style: StyleObjectPropType,
     };
     const values = {
         style: value,


### PR DESCRIPTION
**Backwards Compatibility Implications**

_None_

**New Features**

- add prefix as an option instead of an icon, that only shows when an input has focus or a value

**Bug Fixes**

_None_