### PR TITLE
Set flatpickr version to 4.3.2 and fix DateField

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   "dependencies": {
     "autosize": "^4.0.0",
     "classnames": "^2.2.5",
-    "flatpickr": "^4.3.2",
+    "flatpickr": "4.3.2",
     "prop-types": "15.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,9 +4127,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@^4.3.2:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.4.4.tgz#fdeb083ca3d580eecb822a4080f67b06f0294fc7"
+flatpickr@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.3.2.tgz#6a477043c075ef36c3ff54fadb49b936a64d635f"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

- Reverts Flatpickr version in the yarn.lock to v4.3.2 so it might cause compatibility issues to anyone who was relying on Flatpickr version 4.4.4

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

- Fix the layout of week day labels in date pickers
- Fix the functionality of month arrows in the `DateField` component's date picker
