### PR TITLE
Close Avatar Menu on click-outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "autosize": "^4.0.0",
     "classnames": "^2.2.5",
     "flatpickr": "4.3.2",
-    "prop-types": "15.6.0"
+    "prop-types": "15.6.0",
+    "react-click-outside": "^3.0.1"
   }
 }

--- a/src/components/Avatar/AvatarMenu.js
+++ b/src/components/Avatar/AvatarMenu.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import clickOutside from 'react-click-outside';
 import StyleObjectPropType from '../../prop-types/style';
 import AvatarMenuItem from './AvatarMenu/AvatarMenuItem';
 import AvatarMenuNav from './AvatarMenu/AvatarMenuNav';
@@ -29,7 +30,7 @@ const defaultProps = {
     style: null,
 };
 
-class AvatarMenu extends Component {
+class UnwrappedAvatarMenu extends Component {
     state = {
         open: this.props.open,
     }
@@ -39,6 +40,8 @@ class AvatarMenu extends Component {
     }
 
     handleClick = () => this.setState({ open: false })
+
+    handleClickOutside = () => this.setState({ open: false });
 
     handleKeyDown = (event) => {
         if (event.key === 'Enter') {
@@ -85,10 +88,16 @@ class AvatarMenu extends Component {
     )
 }
 
-AvatarMenu.propTypes = propTypes;
-AvatarMenu.defaultProps = defaultProps;
+UnwrappedAvatarMenu.propTypes = propTypes;
+UnwrappedAvatarMenu.defaultProps = defaultProps;
+
+const AvatarMenu = clickOutside(UnwrappedAvatarMenu);
 
 AvatarMenu.Nav = AvatarMenuNav;
 AvatarMenu.Item = AvatarMenuItem;
+
+// Duplicated for Storybook introspection
+AvatarMenu.defaultProps = defaultProps;
+AvatarMenu.propTypes = propTypes;
 
 export default AvatarMenu;

--- a/src/components/Avatar/AvatarMenu.story.js
+++ b/src/components/Avatar/AvatarMenu.story.js
@@ -132,3 +132,54 @@ The prop \`position\` adjusts where the \`AvatarMenu\` is displayed. The default
         </AvatarMenu>,
     ),
 );
+
+stories.add(
+    'Close on Click',
+    storyWrapper(
+        `
+The AvatarMenu can be closed by clicking outside
+        `,
+        <AvatarMenu
+            avatar={<Avatar name="Jane Smith" src="https://randomuser.me/api/portraits/women/49.jpg" />}
+            position={AvatarMenuPosition.RIGHT}
+        >
+            <AvatarMenu.Nav>
+                <AvatarMenu.Item>
+                    <Button onClick={() => {}} variant="clear">
+                        Feedback
+                    </Button>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item>
+                    <Button onClick={() => {}} variant="clear">
+                        Settings
+                    </Button>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item>
+                    <Button onClick={() => {}} variant="clear">
+                        Logout
+                    </Button>
+                </AvatarMenu.Item>
+            </AvatarMenu.Nav>
+            <AvatarMenu.Nav>
+                <AvatarMenu.Item icon={<IconDashboard />}>
+                    <a href="//">My Dashboard</a>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item icon={<IconPriority />}>
+                    <a href="//">Priority Tracker</a>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item icon={<IconDashboard />}>
+                    <a href="//">Project Status</a>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item icon={<IconProject />}>
+                    <a href="//">Example Project</a>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item icon={<IconProject />}>
+                    <a href="//">Example Project</a>
+                </AvatarMenu.Item>
+                <AvatarMenu.Item hasSpacer>
+                    <a href="//">Add Project</a>
+                </AvatarMenu.Item>
+            </AvatarMenu.Nav>
+        </AvatarMenu>,
+    ),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4744,6 +4744,10 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
+hoist-non-react-statics@^2.1.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -7854,6 +7858,12 @@ rc@~1.0.0:
     ini "~1.3.0"
     minimist "~0.0.7"
     strip-json-comments "0.1.x"
+
+react-click-outside@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
 
 react-color@^2.14.0:
   version "2.14.1"


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

The Avatar Menu will now close when clicked outside of.

**Performance Improvements** <!-- List performance improvements, or remove section if there are none. -->

**Miscellaneous** <!-- List anything else changed in this PR, for example 'Updated documentation', or remove section if there are none. -->

- Added a click-to-close example to Storybook