### PR TITLE
Fix Tabs stealing focus on rerender

### DIFF
--- a/src/components/Tabs/TabsPane.js
+++ b/src/components/Tabs/TabsPane.js
@@ -30,6 +30,12 @@ class TabsPane extends Component {
         });
     }
 
+    componentDidUpdate() {
+        if (this.state.isSelecting) {
+            this.focusPane();
+        }
+    }
+
     focusPane() {
         if (!this.componentRef) { return; }
 
@@ -45,8 +51,6 @@ class TabsPane extends Component {
     }
 
     render() {
-        this.focusPane();
-
         return (
             <section
                 aria-hidden={!this.props.isSelected}


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

The active pane in a set of Tabs will no longer steal focus each time its parent triggers a re-render. In theory, someone could have been relying on this behaviour, but it seems unlikely.

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

Call to `focusPane` on `render` now takes place in `componentDidUpdate` only when moving from unselected to selected. This fixes a bug where a TabsPane would steal focus from a sibling input whenever their parent triggered a re-render.
