### PR TITLE
Fixes TextField label overlapping the autofilled value in Chrome

### DIFF
--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -107,12 +107,21 @@ class TextField extends Component {
         this.state = {
             hasFocus: false,
             hasMouseOver: false,
+            isAutofilled: false,
             showTooltip: false,
             value: props.value,
         };
 
         lastInstanceId += 1;
         this.uid = `text-field-${lastInstanceId}`;
+    }
+
+    componentDidMount() {
+        const { inputRef } = this;
+
+        if (inputRef && inputRef.addEventListener) {
+            inputRef.addEventListener('animationstart', this.handleInputAnimationStart);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -155,6 +164,19 @@ class TextField extends Component {
 
     handleMouseLeave = () => {
         this.setState({ hasMouseOver: false });
+    }
+
+    handleInputAnimationStart = (event) => {
+        switch (event.animationName) {
+        case 'uirOnAutoFillStart':
+            this.setState({ isAutofilled: true });
+            break;
+        case 'uirOnAutoFillCancel':
+            this.setState({ isAutofilled: false });
+            break;
+        default:
+            break;
+        }
     }
 
     handleInputRef = (ref) => {
@@ -261,7 +283,8 @@ class TextField extends Component {
     }
 
     render() {
-        const hasValue = this.state.value === 0 ? true : Boolean(this.state.value);
+        const hasValue = this.state.isAutofilled ||
+            (this.state.value === 0 ? true : Boolean(this.state.value));
         const showLabel = (
             this.props.autoHideLabel === false ||
             this.state.hasFocus ||

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -166,6 +166,10 @@ class TextField extends Component {
         this.setState({ hasMouseOver: false });
     }
 
+    /*
+     * This is used to detect Chrome autofill
+     * For explanation see: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
+     */
     handleInputAnimationStart = (event) => {
         switch (event.animationName) {
         case 'uirOnAutoFillStart':

--- a/src/components/Fields/TextField.scss
+++ b/src/components/Fields/TextField.scss
@@ -135,8 +135,32 @@ $textFieldLabelColor: $charcoal !default;
         border: 0;
         outline: none;
 
+        @keyframes uirOnAutoFillStart {
+            // Use empty animation definitions to ensure they are included in production CSS
+            from {/**/}
+
+            to {/**/}
+        }
+
+        @keyframes uirOnAutoFillCancel {
+            // Use empty animation definitions to ensure they are included in production CSS
+            from {/**/}
+
+            to {/**/}
+        }
+
         &:invalid {
             box-shadow: none; // hide Firefox invalid shadow
+        }
+
+        &:-webkit-autofill {
+            // Expose a hook for JS when auto fill is shown.
+            animation-name: uirOnAutoFillStart;
+        }
+
+        &:not(:-webkit-autofill) {
+            // Expose a hook for JS when auto fill is removed
+            animation-name: uirOnAutoFillCancel;
         }
     }
 

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -1,4 +1,4 @@
-/* global describe, expect, it, shallow, mount */
+/* global AnimationEvent, describe, expect, it, shallow, mount */
 import React from 'react';
 import sinon from 'sinon';
 import * as common from '../../../test/unit/commonTests';
@@ -467,6 +467,31 @@ describe('TextField', () => {
             const textField = mount(<TextField prefix="£" value={mockValue} />);
             textField.find(Button).simulate('click');
             expect(textField.state('value')).to.equal(mockValue);
+        });
+    });
+
+    describe('browser autofill', () => {
+        it('adds --has-value class when Chrome autofill is detected using CSS animations', () => {
+            const textField = mount(<TextField />);
+            const inputNode = textField.find('input').getDOMNode();
+            inputNode.dispatchEvent(new AnimationEvent('animationstart', { animationName: 'uirOnAutoFillStart' }));
+            expect(textField).to.have.className('uir-text-field--has-value');
+        });
+
+        it('removes a previously added --has-value class when Chrome autofill removal is detected', () => {
+            const textField = mount(<TextField />);
+            const inputNode = textField.find('input').getDOMNode();
+            inputNode.dispatchEvent(new AnimationEvent('animationstart', { animationName: 'uirOnAutoFillStart' }));
+            expect(textField).to.have.className('uir-text-field--has-value');
+            inputNode.dispatchEvent(new AnimationEvent('animationstart', { animationName: 'uirOnAutoFillCancel' }));
+            expect(textField).not.to.have.className('uir-text-field--has-value');
+        });
+
+        it('does not add a --has-value class when an unrelated CSS animation is detected', () => {
+            const textField = mount(<TextField />);
+            const inputNode = textField.find('input').getDOMNode();
+            inputNode.dispatchEvent(new AnimationEvent('animationstart', { animationName: 'test' }));
+            expect(textField).not.to.have.className('uir-text-field--has-value');
         });
     });
 });


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

- Fixes `TextField` label overlapping the autofilled field value in Chrome
Thanks to the Klarna team for the solution: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
Their implementation can be found here:
https://github.com/klarna/ui/blob/v4.10.0/Field/index.jsx#L104-L114
https://github.com/klarna/ui/blob/v4.10.0/Field/styles.scss#L228-L241
