### PR TITLE
Fix missing icons exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,16 +12,23 @@ import DateInlinePicker from './DateInlinePicker';
 
 import IconArrow from './IconArrow';
 import IconArrowLongRight from './IconArrowLongRight';
+import IconBlocked from './IconBlocked';
 import IconCalendar from './IconCalendar';
 import IconClear from './IconClear';
+import IconComplete from './IconComplete';
 import IconDashboard from './IconDashboard';
+import IconEpic from './IconEpic';
+import IconInProgress from './IconInProgress';
 import IconKanban from './IconKanban';
 import IconMore from './IconMore';
 import IconNotification from './IconNotification';
+import IconNotStarted from './IconNotStarted';
 import IconPriority from './IconPriority';
 import IconProject from './IconProject';
 import IconRequired from './IconRequired';
 import IconSearch from './IconSearch';
+import IconStory from './IconStory';
+import IconTask from './IconTask';
 
 import Tabs from './Tabs';
 
@@ -43,16 +50,23 @@ export {
     DateInlinePicker,
     IconArrow,
     IconArrowLongRight,
+    IconBlocked,
     IconCalendar,
     IconClear,
+    IconComplete,
     IconDashboard,
+    IconEpic,
+    IconInProgress,
     IconKanban,
     IconMore,
     IconNotification,
+    IconNotStarted,
     IconPriority,
     IconProject,
     IconRequired,
     IconSearch,
+    IconStory,
+    IconTask,
     Tabs,
     TextArea,
     TextField,


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

- Add missing `/lib` exports for the latest icons (added in https://github.com/Mudano/ui-react/pull/126 ) to ensure they can be imported directly from `@mudano/ui-react`
