### PR TITLE
Add minLength and maxLength props to TextField

### DIFF
--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -28,7 +28,9 @@ const propTypes = {
     isValid: PropTypes.bool,
     label: PropTypes.string,
     max: PropTypes.number,
+    maxLength: PropTypes.number,
     min: PropTypes.number,
+    minLength: PropTypes.number,
     name: PropTypes.string,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
@@ -76,7 +78,9 @@ const defaultProps = {
     isValid: null,
     label: null,
     max: null,
+    maxLength: null,
     min: null,
+    minLength: null,
     name: null,
     onBlur: null,
     onChange: null,
@@ -395,7 +399,9 @@ class TextField extends Component {
                             disabled={this.props.isDisabled}
                             id={this.uid}
                             max={this.props.max}
+                            maxLength={this.props.maxLength}
                             min={this.props.min}
+                            minLength={this.props.minLength}
                             name={this.props.name}
                             onChange={this.handleInputChange}
                             onBlur={this.handleInputBlur}

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -224,6 +224,22 @@ stories.add(
 );
 
 stories.add(
+    'Min and Max Length',
+    storyWrapper(
+        `
+\`minLength\` and \`maxLength\` allow you to set the minimum and maximum length of the input value.
+
+_NB: \`minLength\` does not visibly change the Component when the input value isn't long enough. Client code should handle this with \`isValid\`._
+        `,
+        <TextField label="Max Length 5" maxLength={5} />,
+        <div>
+            <TextField label="Min Length 5" minLength={5} />
+            <TextField label="Min Length 5, Max Length 15" minLength={5} maxLength={15} />
+        </div>,
+    ),
+);
+
+stories.add(
     'Validation',
     storyWrapper(
         '`isValid` allows you to control input validation state.',

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -182,6 +182,13 @@ describe('TextField', () => {
         expect(textField.find('input').prop('step')).to.equal(3);
     });
 
+    it('allows minLength and maxLength to be set', () => {
+        const textField = shallow(<TextField label="My Input" type="text" minLength={5} maxLength={15} />);
+        expect(textField.find('input').prop('type')).to.equal('text');
+        expect(textField.find('input').prop('minLength')).to.equal(5);
+        expect(textField.find('input').prop('maxLength')).to.equal(15);
+    });
+
     ['blur', 'change', 'focus', 'keyDown', 'keyPress', 'keyUp'].forEach((event) => {
         it(`triggers handler on input ${event}`, () => {
             const spy = sinon.spy();


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

- Added `minLength` and `maxLength` props to `TextField`

**Note**: Because we allow client code to completely control (e.g.) validation state on TextField, there isn't an easy way of showing when an input value is too short. This is reflected in the updated documentation.

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

_None_
