### PR TITLE
[SPS-29] Add autoComplete prop to TextField and TextArea

### DIFF
--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -23,6 +23,7 @@ const propTypes = {
     isValid: PropTypes.bool,
     label: PropTypes.string,
     name: PropTypes.string,
+    autoComplete: PropTypes.oneOf(['on', 'off']),
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onEnterKey: PropTypes.func,
@@ -51,6 +52,7 @@ const defaultProps = {
     isValid: null,
     label: null,
     name: null,
+    autoComplete: null,
     onBlur: null,
     onChange: null,
     onEnterKey: null,
@@ -247,6 +249,7 @@ class TextArea extends Component {
                             disabled={this.props.isDisabled}
                             id={this.uid}
                             name={this.props.name}
+                            autoComplete={this.props.autoComplete}
                             onChange={this.handleInputChange}
                             onBlur={this.handleInputBlur}
                             onFocus={this.handleInputFocus}

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -207,3 +207,17 @@ stories.add(
         </div>,
     ),
 );
+
+stories.add(
+    'Autocomplete',
+    storyWrapper(
+        `
+\`autoComplete\` prop allows you to control whether the browser should autocomplete input value
+        `,
+        <TextArea label="Description" name="description" autoComplete="on" />,
+        <div>
+            <TextArea label="Description" name="description" autoComplete="on" />,
+            <TextArea label="No autocomplete description" name="description" autoComplete="off" />
+        </div>,
+    ),
+);

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -173,6 +173,13 @@ describe('TextArea', () => {
         mount(<TextArea />);
     });
 
+    it('accepts autoComplete prop', () => {
+        const textArea = mount(<TextArea autoComplete="off" />);
+        const input = textArea.find('textarea');
+
+        expect(input.prop('autoComplete')).to.equal('off');
+    });
+
     ['blur', 'change', 'focus', 'keyDown', 'keyPress', 'keyUp'].forEach((event) => {
         it(`triggers handler on textarea ${event}`, () => {
             const spy = sinon.spy();

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -30,6 +30,7 @@ const propTypes = {
     max: PropTypes.number,
     min: PropTypes.number,
     name: PropTypes.string,
+    autoComplete: PropTypes.oneOf(['on', 'off']),
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onEnterKey: PropTypes.func,
@@ -78,6 +79,7 @@ const defaultProps = {
     max: null,
     min: null,
     name: null,
+    autoComplete: null,
     onBlur: null,
     onChange: null,
     onEnterKey: null,
@@ -397,6 +399,7 @@ class TextField extends Component {
                             max={this.props.max}
                             min={this.props.min}
                             name={this.props.name}
+                            autoComplete={this.props.autoComplete}
                             onChange={this.handleInputChange}
                             onBlur={this.handleInputBlur}
                             onFocus={this.handleInputFocus}

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -409,7 +409,7 @@ stories.add(
         `,
         <TextField label="Username" name="username" autoComplete="on" />,
         <div>
-            <TextField label="Username" name="username" autoComplete="on" />,
+            <TextField label="Username" name="username" autoComplete="on" />
             <TextField label="No autocomplete" name="username" autoComplete="off" />
         </div>,
     ),

--- a/src/components/Fields/TextField.story.js
+++ b/src/components/Fields/TextField.story.js
@@ -400,3 +400,17 @@ _NB: if you add a prefix and an icon, only the prefix will be displayed_
         </div>,
     ),
 );
+
+stories.add(
+    'Autocomplete',
+    storyWrapper(
+        `
+\`autoComplete\` prop allows you to control whether the browser should autocomplete input value
+        `,
+        <TextField label="Username" name="username" autoComplete="on" />,
+        <div>
+            <TextField label="Username" name="username" autoComplete="on" />,
+            <TextField label="No autocomplete" name="username" autoComplete="off" />
+        </div>,
+    ),
+);

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -426,6 +426,13 @@ describe('TextField', () => {
         expect(textField.instance().inputRef.selectionEnd).to.equal(2);
     });
 
+    it('accepts autoComplete prop', () => {
+        const textField = mount(<TextField autoComplete="off" />);
+        const input = textField.find('input');
+
+        expect(input.prop('autoComplete')).to.equal('off');
+    });
+
     describe('prefix', () => {
         it('displays a prefix if value present', () => {
             const textField = shallow(<TextField prefix="£" value="test" />);


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

New `autoComplete` prop on TextField and TextArea

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

_None_

**Performance Improvements** <!-- List performance improvements, or remove section if there are none. -->


**Miscellaneous** <!-- List anything else changed in this PR, for example 'Updated documentation', or remove section if there are none. -->
