### PR TITLE
Fix broken TextArea autosizing and focus

### DIFF
--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -98,6 +98,29 @@ class TextArea extends Component {
         }
     }
 
+    componentDidUpdate(prevProps) {
+        const { hasFocus } = this.state;
+        const { tooltipError, isValid } = this.props;
+
+        const isShowingErrorTooltip = !isValid && !!tooltipError;
+        const wasShowingErrorTooltip = !prevProps.isValid && !!prevProps.tooltipError;
+        if (
+            (hasFocus && isShowingErrorTooltip && !wasShowingErrorTooltip) ||
+            (hasFocus && !isShowingErrorTooltip && wasShowingErrorTooltip)
+        ) {
+            this.fixInputFocus();
+        }
+        autosize.destroy(this.inputRef);
+        autosize(this.inputRef);
+    }
+
+    fixInputFocus() {
+        const { inputRef } = this;
+        inputRef.focus();
+        inputRef.selectionStart = inputRef.value.length;
+        inputRef.selectionEnd = inputRef.value.length;
+    }
+
     handleMouseEnter = () => {
         this.setState({ hasMouseOver: true });
     }

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -104,14 +104,15 @@ class TextArea extends Component {
 
         const isShowingErrorTooltip = !isValid && !!tooltipError;
         const wasShowingErrorTooltip = !prevProps.isValid && !!prevProps.tooltipError;
+
         if (
             (hasFocus && isShowingErrorTooltip && !wasShowingErrorTooltip) ||
             (hasFocus && !isShowingErrorTooltip && wasShowingErrorTooltip)
         ) {
+            autosize.destroy(this.inputRef);
+            autosize(this.inputRef);
             this.fixInputFocus();
         }
-        autosize.destroy(this.inputRef);
-        autosize(this.inputRef);
     }
 
     fixInputFocus() {

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import storyWrapper from '../../storybook-addons/storyWrapper';
 import TextArea from './TextArea';
@@ -10,6 +10,44 @@ const multilineText = `Lorem ipsum dolor sit amet, consectetur adipisicing elit.
 Velit ipsam, nesciunt doloribus, aspernatur a itaque assumenda odit alias rem dignissimos culpa error magnam veniam cupiditate repellendus nam id perferendis sit.
 
 Velit ipsam, nesciunt doloribus, aspernatur a itaque assumenda odit alias rem dignissimos culpa error magnam veniam cupiditate repellendus nam id perferendis sit.`;
+
+const MAX_COMMENT_LENGTH = 50;
+
+class CharartersLimitDemo extends Component {
+    state = {
+        isValid: true,
+        comment: '',
+        errorMessage: '',
+    }
+
+    handleCommentChange(value) {
+        if (value.length > MAX_COMMENT_LENGTH) {
+            this.setState({
+                isValid: false,
+                errorMessage: `Comment should have ${MAX_COMMENT_LENGTH} characters or fewer`,
+            });
+            return;
+        }
+
+        this.setState({
+            comment: value,
+            isValid: true,
+            errorMessage: '',
+        });
+    }
+
+    render() {
+        return (
+            <TextArea
+                label="Input with characters limit error"
+                tooltipError={this.state.errorMessage}
+                isValid={this.state.isValid}
+                value={this.state.comment}
+                onChange={value => this.handleCommentChange(value)}
+            />
+        );
+    }
+}
 
 stories.add(
     'Overview',
@@ -172,6 +210,7 @@ _NB: tooltipError will ONLY be displayed if isValid is false._
                 label="Input with a hint"
                 tooltipHint="My Example Hint"
             />
+            <CharartersLimitDemo />
         </div>,
     ),
 );

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -13,7 +13,7 @@ Velit ipsam, nesciunt doloribus, aspernatur a itaque assumenda odit alias rem di
 
 const MAX_COMMENT_LENGTH = 50;
 
-class CharartersLimitDemo extends Component {
+class CharactersLimitDemo extends Component {
     state = {
         isValid: true,
         comment: '',
@@ -210,7 +210,7 @@ _NB: tooltipError will ONLY be displayed if isValid is false._
                 label="Input with a hint"
                 tooltipHint="My Example Hint"
             />
-            <CharartersLimitDemo />
+            <CharactersLimitDemo />
         </div>,
     ),
 );

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -335,7 +335,7 @@ describe('TextArea', () => {
         expect(textField.instance().inputRef.focus).to.be.called();
     });
 
-    it('fixInputFocus sets input the selection to the last character', () => {
+    it('fixInputFocus sets the input selection to the last character', () => {
         const textField = mount(<TextArea />);
         textField.instance().inputRef = {
             focus: sinon.spy(),

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -304,4 +304,46 @@ describe('TextArea', () => {
         const textField = shallow(<TextArea />);
         expect(textField.hasClass('uir-text-area--has-value')).to.not.equal(true);
     });
+
+    it('fixes input focus when it\'s wrapped by tooltip', () => {
+        const textField = mount(<TextArea isValid tooltipError="Error" />);
+        textField.setState({ hasFocus: true });
+        sinon.spy(textField.instance(), 'fixInputFocus');
+
+        textField.setProps({
+            isValid: false,
+        });
+        expect(textField.instance().fixInputFocus).to.be.called();
+    });
+
+    it('fixes input focus when it ceases to be wrapped by a tooltip', () => {
+        const textField = mount(<TextArea isValid={false} tooltipError="Error" />);
+        textField.setState({ hasFocus: true });
+        sinon.spy(textField.instance(), 'fixInputFocus');
+
+        textField.setProps({
+            isValid: true,
+        });
+        expect(textField.instance().fixInputFocus).to.be.called();
+    });
+
+    it('fixInputFocs calls input ref focus', () => {
+        const textField = mount(<TextArea />);
+        sinon.spy(textField.instance().inputRef, 'focus');
+        textField.instance().fixInputFocus();
+
+        expect(textField.instance().inputRef.focus).to.be.called();
+    });
+
+    it('fixInputFocs sets input the selection to the last character', () => {
+        const textField = mount(<TextArea />);
+        textField.instance().inputRef = {
+            focus: sinon.spy(),
+            value: 'ab',
+        };
+        textField.instance().fixInputFocus();
+
+        expect(textField.instance().inputRef.selectionStart).to.equal(2);
+        expect(textField.instance().inputRef.selectionEnd).to.equal(2);
+    });
 });

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -327,7 +327,7 @@ describe('TextArea', () => {
         expect(textField.instance().fixInputFocus).to.be.called();
     });
 
-    it('fixInputFocs calls input ref focus', () => {
+    it('fixInputFocus calls input ref focus', () => {
         const textField = mount(<TextArea />);
         sinon.spy(textField.instance().inputRef, 'focus');
         textField.instance().fixInputFocus();
@@ -335,7 +335,7 @@ describe('TextArea', () => {
         expect(textField.instance().inputRef.focus).to.be.called();
     });
 
-    it('fixInputFocs sets input the selection to the last character', () => {
+    it('fixInputFocus sets input the selection to the last character', () => {
         const textField = mount(<TextArea />);
         textField.instance().inputRef = {
             focus: sinon.spy(),


### PR DESCRIPTION
**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

- Fixed `TextArea` loosing its autosize and focus when rendering tooltips
