### PR TITLE
Enforce alphabetical props order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
         "indent": ["error", 4],
         "react/jsx-indent": ["error", 4],
         "react/jsx-indent-props": ["error", 4],
-        "react/jsx-filename-extension": [1, { "extensions": [".js"] }]
+        "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
+        "react/sort-prop-types": ["error", 4]
     },
     "globals": {
     }

--- a/src/components/Avatar/AvatarMenu.js
+++ b/src/components/Avatar/AvatarMenu.js
@@ -11,13 +11,13 @@ import './AvatarMenu.scss';
 
 const propTypes = {
     avatar: PropTypes.element.isRequired,
-    className: PropTypes.string,
     children: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.element,
         PropTypes.number,
         PropTypes.string,
     ]).isRequired,
+    className: PropTypes.string,
     open: PropTypes.bool,
     position: PropTypes.string,
     style: StyleObjectPropType,

--- a/src/components/Avatar/AvatarMenu/AvatarMenuItem.js
+++ b/src/components/Avatar/AvatarMenu/AvatarMenuItem.js
@@ -5,15 +5,15 @@ import StyleObjectPropType from '../../../prop-types/style';
 import { proxyDataProps } from '../../../utils/data-props';
 
 const propTypes = {
-    className: PropTypes.string,
     children: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.element,
         PropTypes.number,
         PropTypes.string,
     ]).isRequired,
-    icon: PropTypes.element,
+    className: PropTypes.string,
     hasSpacer: PropTypes.bool,
+    icon: PropTypes.element,
     style: StyleObjectPropType,
 };
 

--- a/src/components/Avatar/AvatarMenu/AvatarMenuNav.js
+++ b/src/components/Avatar/AvatarMenu/AvatarMenuNav.js
@@ -5,11 +5,11 @@ import StyleObjectPropType from '../../../prop-types/style';
 import { proxyDataProps } from '../../../utils/data-props';
 
 const propTypes = {
-    className: PropTypes.string,
     children: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.element),
         PropTypes.element,
     ]).isRequired,
+    className: PropTypes.string,
     style: StyleObjectPropType,
 };
 

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -12,6 +12,7 @@ const propTypes = {
     'aria-expanded': PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
+    componentRef: PropTypes.func,
     confirmText: PropTypes.string,
     confirmedText: PropTypes.string,
     hasConfirm: PropTypes.bool,
@@ -27,7 +28,6 @@ const propTypes = {
     onClick: PropTypes.func.isRequired,
     style: StyleObjectPropType,
     tabIndex: PropTypes.number,
-    componentRef: PropTypes.func,
     type: ListPropType([
         ButtonType.BUTTON,
         ButtonType.RESET,

--- a/src/components/Fields/DateField.js
+++ b/src/components/Fields/DateField.js
@@ -13,6 +13,14 @@ import './DateField.scss';
 
 const propTypes = {
     className: PropTypes.string,
+    datePickerPosition: ListPropType([
+        TooltipPosition.TOP_CENTER,
+        TooltipPosition.TOP_LEFT,
+        TooltipPosition.TOP_RIGHT,
+        TooltipPosition.BOTTOM_CENTER,
+        TooltipPosition.BOTTOM_RIGHT,
+        TooltipPosition.BOTTOM_LEFT,
+    ]),
     forceHideCalendar: PropTypes.bool,
     isRange: PropTypes.bool,
     maxDate: PropTypes.instanceOf(Date),
@@ -23,14 +31,6 @@ const propTypes = {
     rangeFromValue: PropTypes.instanceOf(Date),
     rangeToValue: PropTypes.instanceOf(Date),
     style: StyleObjectPropType,
-    datePickerPosition: ListPropType([
-        TooltipPosition.TOP_CENTER,
-        TooltipPosition.TOP_LEFT,
-        TooltipPosition.TOP_RIGHT,
-        TooltipPosition.BOTTOM_CENTER,
-        TooltipPosition.BOTTOM_RIGHT,
-        TooltipPosition.BOTTOM_LEFT,
-    ]),
     value: PropTypes.instanceOf(Date),
 };
 

--- a/src/components/Icon/IconStory.js
+++ b/src/components/Icon/IconStory.js
@@ -11,14 +11,14 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType,
+    isBlocked: PropTypes.bool,
     priority: ListPropType([
         IconPriority.NONE,
         IconPriority.LOW,
         IconPriority.MEDIUM,
         IconPriority.HIGH,
     ]),
-    isBlocked: PropTypes.bool,
+    style: StyleObjectPropType,
     title: PropTypes.string,
 };
 

--- a/src/components/Icon/IconTask.js
+++ b/src/components/Icon/IconTask.js
@@ -11,14 +11,14 @@ let lastInstanceId = 0;
 
 const propTypes = {
     className: PropTypes.string,
-    style: StyleObjectPropType,
+    isBlocked: PropTypes.bool,
     priority: ListPropType([
         IconPriority.NONE,
         IconPriority.LOW,
         IconPriority.MEDIUM,
         IconPriority.HIGH,
     ]),
-    isBlocked: PropTypes.bool,
+    style: StyleObjectPropType,
     title: PropTypes.string,
 };
 


### PR DESCRIPTION
<!-- Remember to use a meaningful title which can be used in release notes. For example: Adds some cool new feature -->

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->

_None_

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

_None_

**Miscellaneous** <!-- List anything else changed in this PR, for example 'Updated documentation', or remove section if there are none. -->

- Added an ESLint rule to enforce prop type declaration order. This is something we have agreed on from the very beginning but never linted for.
