### PR TITLE
Textarea - Validation message under the field

### DIFF
--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -16,6 +16,7 @@ const propTypes = {
     autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
     componentRef: PropTypes.func,
+    errorMessageType: PropTypes.oneOf(['tooltip', 'message']),
     hasFixedHeight: PropTypes.bool,
     isDisabled: PropTypes.bool,
     isFullWidth: PropTypes.bool,
@@ -37,6 +38,7 @@ const propTypes = {
     tooltipError: ElementOrStringPropType,
     tooltipHint: ElementOrStringPropType,
     tooltipRequired: ElementOrStringPropType,
+    validationMessage: PropTypes.string,
     value: PropTypes.string,
 };
 
@@ -45,6 +47,7 @@ const defaultProps = {
     autoHideLabel: false,
     className: null,
     componentRef: null,
+    errorMessageType: 'tooltip',
     hasFixedHeight: false,
     isDisabled: false,
     isFullWidth: false,
@@ -66,6 +69,7 @@ const defaultProps = {
     tooltipError: null,
     tooltipHint: null,
     tooltipRequired: 'required',
+    validationMessage: null,
     value: '',
 };
 
@@ -238,7 +242,12 @@ class TextArea extends Component {
             null;
         /* eslint-enable */
         const showPlaceholder = (!this.props.label || this.state.hasFocus);
-        const tooltipError = this.props.isValid === false ? this.props.tooltipError : null;
+        const showValidationMessage = !this.props.isValid && this.props.errorMessageType === 'message'
+            && (this.props.validationMessage || this.props.tooltipError);
+        const validationMessage = showValidationMessage ?
+            this.props.validationMessage || this.props.tooltipError : null;
+        const tooltipError = (!showValidationMessage && !this.props.isValid
+            ? this.props.tooltipError : null);
         return (
             <div
                 className={cx(
@@ -251,7 +260,6 @@ class TextArea extends Component {
                         'uir-text-area--full-width': this.props.isFullWidth,
                         'uir-text-area--has-right-icon': this.props.isRequired,
                         'uir-text-area--has-value': this.state.value === null ? false : `${this.state.value}`,
-                        'uir-text-area--invalid': this.props.isValid === false,
                         'uir-text-area--readonly': this.props.isReadOnly,
                         'uir-text-area--valid': this.props.isValid,
                     },
@@ -262,38 +270,49 @@ class TextArea extends Component {
                 style={this.props.style}
                 {...proxyDataProps(this.props)}
             >
-                <div className="uir-text-area-inner">
-                    <div className="uir-text-area-label-wrapper">
-                        {label}
+                <div>
+                    <div
+                        className={cx(
+                            'uir-text-area-inner',
+                            {
+                                'uir-text-area-inner--invalid': this.props.isValid === false,
+                                'uir-text-area-inner--disabled': this.props.isDisabled,
+                            },
+                        )}
+                    >
+                        <div className="uir-text-area-label-wrapper">
+                            {label}
+                        </div>
+                        {this.wrapInputWithTooltip(
+                            <textarea
+                                aria-invalid={this.props.isValid === false}
+                                autoComplete={this.props.autoComplete}
+                                className="uir-text-area-input"
+                                disabled={this.props.isDisabled}
+                                id={this.uid}
+                                name={this.props.name}
+                                onChange={this.handleInputChange}
+                                onBlur={this.handleInputBlur}
+                                onFocus={this.handleInputFocus}
+                                onKeyDown={this.handleInputKeyDown}
+                                onKeyUp={this.handleInputKeyUp}
+                                onKeyPress={this.handleInputKeyPress}
+                                placeholder={showPlaceholder ? this.props.placeholder : null}
+                                readOnly={this.props.isReadOnly}
+                                required={this.props.isRequired}
+                                ref={this.handleInputRef}
+                                rows={this.props.rows}
+                                value={this.state.value === null ? '' : this.state.value}
+                            />,
+                            tooltipError || this.props.tooltipHint,
+                        )}
+                        {requiredIconAndTooltip(
+                            this.props.isRequired && !this.props.label,
+                            this.props.tooltipRequired,
+                        )}
                     </div>
-                    {this.wrapInputWithTooltip(
-                        <textarea
-                            aria-invalid={this.props.isValid === false}
-                            autoComplete={this.props.autoComplete}
-                            className="uir-text-area-input"
-                            disabled={this.props.isDisabled}
-                            id={this.uid}
-                            name={this.props.name}
-                            onChange={this.handleInputChange}
-                            onBlur={this.handleInputBlur}
-                            onFocus={this.handleInputFocus}
-                            onKeyDown={this.handleInputKeyDown}
-                            onKeyUp={this.handleInputKeyUp}
-                            onKeyPress={this.handleInputKeyPress}
-                            placeholder={showPlaceholder ? this.props.placeholder : null}
-                            readOnly={this.props.isReadOnly}
-                            required={this.props.isRequired}
-                            ref={this.handleInputRef}
-                            rows={this.props.rows}
-                            value={this.state.value === null ? '' : this.state.value}
-                        />,
-                        tooltipError || this.props.tooltipHint,
-                    )}
-                    {requiredIconAndTooltip(
-                        this.props.isRequired && !this.props.label,
-                        this.props.tooltipRequired,
-                    )}
                 </div>
+                {showValidationMessage && <div className="uir-text-area-validation-message">{validationMessage}</div>}
             </div>
         );
     }

--- a/src/components/Fields/TextArea.scss
+++ b/src/components/Fields/TextArea.scss
@@ -10,24 +10,8 @@ $textFieldLabelColor: $charcoal !default;
     font-weight: 400;
     color: $textFieldLabelColor;
 
-    &:after {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        display: block;
-        width: 40%;
-        height: 1px;
-        content: "";
-        background: linear-gradient(to right, $grey 0%, transparent 100%);
-        transition: width .25s;
-    }
-
     &--focus:after {
         width: 100%;
-    }
-
-    &--invalid:after {
-        background: linear-gradient(to right, $pink 0%, transparent 100%);
     }
 
     &--full-width {
@@ -53,10 +37,6 @@ $textFieldLabelColor: $charcoal !default;
         input::-ms-clear {
             display: none; // hide IE clear icon
         }
-    }
-
-    &--disabled:after {
-        background: none;
     }
 
     &-label-wrapper {
@@ -107,9 +87,41 @@ $textFieldLabelColor: $charcoal !default;
         width: 100%;
     }
 
+    &-validation-message {
+        margin-top: 8px;
+        font-family: "DINOT", Arial, sans-serif;
+        font-size: 11px;
+        font-weight: normal;
+        color: $pink2;
+        letter-spacing: .92px;
+    }
+
     .uir-icon-required {
         width: 10px;
         height: 10px;
         margin-left: 5px;
+    }
+}
+
+.uir-text-area-inner {
+
+    &:after {
+        position: relative;
+        bottom: 0;
+        left: 0;
+        display: inline-block;
+        width: 40%;
+        height: 1px;
+        content: "";
+        background: linear-gradient(to right, $grey 0%, transparent 100%);
+        transition: width .25s;
+    }
+
+    &--invalid:after {
+        background: linear-gradient(to right, $pink 0%, transparent 100%);
+    }
+
+    &--disabled:after {
+        background: none;
     }
 }

--- a/src/components/Fields/TextArea.scss
+++ b/src/components/Fields/TextArea.scss
@@ -92,7 +92,7 @@ $textFieldLabelColor: $charcoal !default;
         font-family: "DINOT", Arial, sans-serif;
         font-size: 11px;
         font-weight: normal;
-        color: $pink2;
+        color: $pink;
         letter-spacing: .92px;
     }
 

--- a/src/components/Fields/TextArea.story.js
+++ b/src/components/Fields/TextArea.story.js
@@ -260,3 +260,17 @@ stories.add(
         </div>,
     ),
 );
+
+stories.add(
+    'Validation message',
+    storyWrapper(
+        '`validationMessage` defines a message to show when `isValid` is `false` and you want to show it instead of a tooltip error. ' +
+        'It works along with `errorMessageType`, which must have the value `message`.',
+        <TextArea
+            label="Invalid input value"
+            errorMessageType="message"
+            validationMessage="The content of this field is invalid"
+            isValid={false}
+        />,
+    ),
+);

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -233,14 +233,16 @@ describe('TextArea', () => {
 
     it('has no validation classes by default', () => {
         const textArea = shallow(<TextArea />);
+        const textAreaInner = textArea.find('.uir-text-area-inner');
         expect(textArea).to.not.have.className('uir-text-area--valid');
-        expect(textArea).to.not.have.className('uir-text-area--invalid');
+        expect(textAreaInner).to.not.have.className('uir-text-area-inner--invalid');
     });
 
     it('has no validation classes if isValid is null', () => {
         const textArea = shallow(<TextArea isValid={null} />);
+        const textAreaInner = textArea.find('.uir-text-area-inner');
         expect(textArea).to.not.have.className('uir-text-area--valid');
-        expect(textArea).to.not.have.className('uir-text-area--invalid');
+        expect(textAreaInner).to.not.have.className('uir-text-area-inner--invalid');
     });
 
     it('adds valid class if isValid is true', () => {
@@ -249,8 +251,8 @@ describe('TextArea', () => {
     });
 
     it('adds invalid class if isValid is false', () => {
-        const textArea = shallow(<TextArea isValid={false} />);
-        expect(textArea).to.have.className('uir-text-area--invalid');
+        const textAreaInner = shallow(<TextArea isValid={false} />).find('.uir-text-area-inner');
+        expect(textAreaInner).to.have.className('uir-text-area-inner--invalid');
     });
 
     it('wraps textarea in a tooltip if tooltipError is given and isValid is false', () => {
@@ -345,5 +347,29 @@ describe('TextArea', () => {
 
         expect(textField.instance().inputRef.selectionStart).to.equal(2);
         expect(textField.instance().inputRef.selectionEnd).to.equal(2);
+    });
+
+    it('does not shows validation message if validationMessage is given but isValid is true', () => {
+        const textArea = shallow(<TextArea isValid errorMessageType="message" validationMessage="This field is invalid" />);
+        expect(textArea.find('.uir-text-area-validation-message').length).to.equal(0);
+    });
+
+    it('does not shows validation message if errorMessageType is not \'message\'', () => {
+        const textArea = shallow(<TextArea isValid={false} validationMessage="This field is invalid" />);
+        expect(textArea.find('.uir-text-area-validation-message').length).to.equal(0);
+    });
+
+    it('shows validation message if errorMessageType is \'message\' and the field is invalid', () => {
+        const textArea = shallow(<TextArea isValid={false} errorMessageType="message" validationMessage="This field is invalid" />);
+        const message = textArea.find('.uir-text-area-validation-message');
+        expect(message.length).to.equal(1);
+        expect(message.text()).to.equal('This field is invalid');
+    });
+
+    it('shows validation message using the tooltipError value if errorMessageType is \'message\' and validationMessage is not provided', () => {
+        const textArea = shallow(<TextArea isValid={false} errorMessageType="message" tooltipError="This field is invalid" />);
+        const message = textArea.find('.uir-text-area-validation-message');
+        expect(message.length).to.equal(1);
+        expect(message.text()).to.equal('This field is invalid');
     });
 });

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -10,4 +10,5 @@ $grey: #ccc !default;
 $charcoal: #2f2833 !default;
 $purple: #9a3cbb !default;
 $pink: #ff1966 !default;
+$pink2: #fc2268 !default;
 $teal: #46bead !default;

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -10,5 +10,4 @@ $grey: #ccc !default;
 $charcoal: #2f2833 !default;
 $purple: #9a3cbb !default;
 $pink: #ff1966 !default;
-$pink2: #fc2268 !default;
 $teal: #46bead !default;


### PR DESCRIPTION
**Backwards Compatibility Implications**
_None_

**New Features** <!-- List new features, or _None_ if there are none. -->
Allow the use of a validation message that will be shown under the textarea field (instead of a tooltip for error)

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->
_None_

**Miscellaneous**
Adds an optional validation message under the field as an alternative to `tooltipError`
![TextArea with validation message](https://user-images.githubusercontent.com/348776/68447182-cbed6180-01bd-11ea-9c98-f7e16cefec4a.png)

1. Choose the type of validation message to `message` (the default is `tooltip`)
2. Provide a value for `validationMessage`
3. When the `isValid` is false the message will be shown under the textarea field
