### PR TITLE
Small Bug fix for Tooltips

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -33,7 +33,7 @@ const propTypes = {
 
 const defaultProps = {
     className: null,
-    position: TooltipPosition.TOP_CENTER,
+    position: TooltipPosition.AUTO,
     showTooltip: null,
     style: null,
     tabIndex: -1,

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -25,7 +25,7 @@
         position: absolute;
         z-index: 1000;
         animation-name: uir-animate-tooltip;
-        animation-duration: .6s;
+        animation-duration: .5s;
         animation-timing-function: ease;
     }
 }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,12 +1,10 @@
 @keyframes uir-animate-tooltip {
 
     from {
-        margin-top: 20px;
         opacity: 0;
     }
 
     to {
-        margin-top: 0;
         opacity: 1;
     }
 }
@@ -27,7 +25,7 @@
         position: absolute;
         z-index: 1000;
         animation-name: uir-animate-tooltip;
-        animation-duration: .2s;
+        animation-duration: .6s;
         animation-timing-function: ease;
     }
 }

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -115,8 +115,8 @@ describe('Tooltip', () => {
         const contents = tooltip.find('.uir-tooltip-contents');
         const { top, left } = contents.props().style;
 
-        expect(top).to.equal('-10px');
-        expect(left).to.equal('0px');
+        expect(top).to.equal('0px');
+        expect(left).to.equal('10px');
     });
 
     [


### PR DESCRIPTION
Fixed the animation issue where the initial position of the tooltip was on top of the trigger, which would cause the tooltip to not show. Changed the default tooltip position to 'auto'.

**Backwards Compatibility Implications** 
- Tooltips will now use 'auto' positioning by default, so if no position is specified through props, it will calculate the best position instead of defaulting to top-center position.

**New Features** 
_None_

**Bug Fixes** 
- Fixed bug where tooltip wasn't triggered when approaching the trigger element from the top or sides, this was caused by the animation 'colliding' with the cursor hovering over the trigger element, which triggered the onMouseLeave event.

**Performance Improvements** 
_None_
