### PR TITLE
Usability: adding tabindex and component ref for some fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mudano/ui-react",
-  "version": "5.2.0",
+  "version": "5.1.3",
   "description": "Mudano UI React Component Library",
   "main": "dist/ui-react.min.js",
   "modules.root": "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mudano/ui-react",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "Mudano UI React Component Library",
   "main": "dist/ui-react.min.js",
   "modules.root": "lib",

--- a/src/components/Fields/DateField.js
+++ b/src/components/Fields/DateField.js
@@ -13,6 +13,8 @@ import './DateField.scss';
 
 const propTypes = {
     className: PropTypes.string,
+    clearButtonRef: PropTypes.func,
+    clearButtonTabIndex: PropTypes.number,
     datePickerPosition: ListPropType([
         TooltipPosition.TOP_CENTER,
         TooltipPosition.TOP_LEFT,
@@ -33,11 +35,14 @@ const propTypes = {
     rangeFromValue: PropTypes.instanceOf(Date),
     rangeToValue: PropTypes.instanceOf(Date),
     style: StyleObjectPropType,
+    tabIndex: PropTypes.number,
+    textFieldRef: PropTypes.func,
     value: PropTypes.instanceOf(Date),
 };
 
 const defaultProps = {
     className: null,
+    clearButtonTabIndex: null,
     forceHideCalendar: false,
     isRange: false,
     maxDate: null,
@@ -49,6 +54,9 @@ const defaultProps = {
     rangeToValue: null,
     style: null,
     datePickerPosition: TooltipPosition.BOTTOM_CENTER,
+    tabIndex: null,
+    textFieldRef: null,
+    clearButtonRef: null,
     value: null,
 };
 
@@ -58,7 +66,7 @@ class DateField extends Component {
         rangeFromValue: this.props.rangeFromValue,
         rangeToValue: this.props.rangeToValue,
         showDatePicker: false,
-    }
+    };
 
     componentWillReceiveProps(nextProps) {
         if (this.props.value !== nextProps.value) {
@@ -105,13 +113,13 @@ class DateField extends Component {
                 [this.state.rangeFromValue, this.state.rangeToValue] :
                 this.state.value);
         });
-    }
+    };
 
     handleInputBlur = (event) => {
         this.datePickerClose();
         const onBlur = this.props.onBlur || (() => {});
         onBlur(event);
-    }
+    };
 
     handleInputChange = (inputValue) => {
         const onChange = this.props.onChange || (() => {});
@@ -126,13 +134,13 @@ class DateField extends Component {
         } else {
             onChange(this.state.value);
         }
-    }
+    };
 
     handleInputFocus = (event) => {
         this.datePickerOpen();
         const onFocus = this.props.onFocus || (() => {});
         onFocus(event);
-    }
+    };
 
     render() {
         const datePickerValues = this.props.isRange ?
@@ -150,7 +158,11 @@ class DateField extends Component {
         />);
         const {
             className,
+            clearButtonTabIndex,
             style,
+            tabIndex,
+            textFieldRef,
+            clearButtonRef,
             ...textFieldProps
         } = this.props;
         return (
@@ -172,6 +184,10 @@ class DateField extends Component {
                         onChange={this.handleInputChange}
                         onFocus={this.handleInputFocus}
                         value={formattedDate || ''}
+                        tabIndex={tabIndex}
+                        clearButtonTabIndex={clearButtonTabIndex}
+                        componentRef={textFieldRef}
+                        clearButtonRef={clearButtonRef}
                     />
                 </Tooltip>
             </div>

--- a/src/components/Fields/DateField.test.js
+++ b/src/components/Fields/DateField.test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import DateField from './DateField';
 import Button from '../Button/Button';
 import * as common from '../../../test/unit/commonTests';
+import TextField from './TextField';
 
 function createMockDate() {
     const mockDate = new Date();
@@ -176,5 +177,46 @@ describe('DateField', () => {
         expect(dateField.state('showDatePicker')).to.be.true();
         dateField.setProps({ forceHideCalendar: false });
         expect(dateField.state('showDatePicker')).to.be.true();
+    });
+
+    it('Correctly passes tabIndex for the DateField', () => {
+        const tabIndex = 2;
+        const dateField = mount(<DateField
+            value={createMockDate()}
+            tabIndex={tabIndex}
+            isClearable
+        />);
+        const textField = dateField.find(TextField);
+        expect(textField.prop('tabIndex')).to.equal(tabIndex);
+    });
+
+    it('Correctly passes tabIndex for the TextField clear button', () => {
+        const dateField = mount(<DateField
+            value={createMockDate()}
+            clearButtonTabIndex={3}
+            isClearable
+        />);
+        const button = dateField.find(Button);
+        expect(button.prop('tabIndex')).to.equal(3);
+    });
+
+    it('Will set the TextField clear button ref when rendering the date field', () => {
+        const clearButtonRef = sinon.spy();
+        mount(<DateField
+            value={createMockDate()}
+            clearButtonRef={clearButtonRef}
+            isClearable
+        />);
+        expect(clearButtonRef).to.be.calledOnce();
+    });
+
+    it('Will set the TextField ref when rendering the date field', () => {
+        const textFieldRef = sinon.spy();
+        mount(<DateField
+            value={createMockDate()}
+            textFieldRef={textFieldRef}
+            isClearable
+        />);
+        expect(textFieldRef).to.be.calledOnce();
     });
 });

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -35,6 +35,7 @@ const propTypes = {
     placeholder: PropTypes.string,
     rows: PropTypes.number,
     style: StyleObjectPropType,
+    tabIndex: PropTypes.number,
     tooltipError: ElementOrStringPropType,
     tooltipHint: ElementOrStringPropType,
     tooltipRequired: ElementOrStringPropType,
@@ -66,6 +67,7 @@ const defaultProps = {
     placeholder: null,
     rows: 1,
     style: null,
+    tabIndex: null,
     tooltipError: null,
     tooltipHint: null,
     tooltipRequired: 'required',
@@ -303,6 +305,7 @@ class TextArea extends Component {
                                 ref={this.handleInputRef}
                                 rows={this.props.rows}
                                 value={this.state.value === null ? '' : this.state.value}
+                                tabIndex={this.props.tabIndex}
                             />,
                             tooltipError || this.props.tooltipHint,
                         )}

--- a/src/components/Fields/TextArea.test.js
+++ b/src/components/Fields/TextArea.test.js
@@ -372,4 +372,10 @@ describe('TextArea', () => {
         expect(message.length).to.equal(1);
         expect(message.text()).to.equal('This field is invalid');
     });
+
+    it('Correctly passes tabIndex for textarea input', () => {
+        const tabIndexValue = 3;
+        const textArea = mount(<TextArea tabIndex={tabIndexValue} />);
+        expect(textArea.prop('tabIndex')).to.equal(tabIndexValue);
+    });
 });

--- a/src/components/Fields/TextField.js
+++ b/src/components/Fields/TextField.js
@@ -19,6 +19,8 @@ const propTypes = {
     autoComplete: PropTypes.oneOf(['on', 'off']),
     autoHideLabel: PropTypes.bool,
     className: PropTypes.string,
+    clearButtonRef: PropTypes.func,
+    clearButtonTabIndex: PropTypes.number,
     componentRef: PropTypes.func,
     icon: ElementOrStringPropType,
     isClearable: PropTypes.bool,
@@ -44,6 +46,7 @@ const propTypes = {
     prefix: ElementOrStringPropType,
     step: PropTypes.number,
     style: StyleObjectPropType,
+    tabIndex: PropTypes.number,
     tooltipError: ElementOrStringPropType,
     tooltipHint: ElementOrStringPropType,
     tooltipPosition: ListPropType([
@@ -72,6 +75,8 @@ const defaultProps = {
     autoComplete: null,
     autoHideLabel: false,
     className: null,
+    clearButtonTabIndex: null,
+    clearButtonRef: null,
     componentRef: null,
     icon: null,
     isClearable: false,
@@ -97,6 +102,7 @@ const defaultProps = {
     prefix: null,
     step: null,
     style: null,
+    tabIndex: null,
     tooltipError: null,
     tooltipHint: null,
     tooltipRequired: 'required',
@@ -164,15 +170,15 @@ class TextField extends Component {
             this.inputRef.value = '';
             this.handleInputChange();
         }
-    }
+    };
 
     handleMouseEnter = () => {
         this.setState({ hasMouseOver: true });
-    }
+    };
 
     handleMouseLeave = () => {
         this.setState({ hasMouseOver: false });
-    }
+    };
 
     /*
      * This is used to detect Chrome autofill
@@ -189,7 +195,7 @@ class TextField extends Component {
         default:
             break;
         }
-    }
+    };
 
     handleInputRef = (ref) => {
         const { componentRef } = this.props;
@@ -197,7 +203,7 @@ class TextField extends Component {
         if (componentRef) {
             componentRef(ref);
         }
-    }
+    };
 
     handleInputBlur = (event) => {
         const onBlur = this.props.onBlur || (() => {});
@@ -206,7 +212,7 @@ class TextField extends Component {
             showTooltip: false,
         });
         onBlur(event);
-    }
+    };
 
     handleInputChange = (event) => {
         if (this.inputRef) {
@@ -217,7 +223,7 @@ class TextField extends Component {
             }
             onChange(value, event);
         }
-    }
+    };
 
     handleInputFocus = (event) => {
         const onFocus = this.props.onFocus || (() => {});
@@ -226,7 +232,7 @@ class TextField extends Component {
             showTooltip: true,
         });
         onFocus(event);
-    }
+    };
 
     handleInputKeyDown = (event) => {
         const { onKeyDown, onEnterKey } = this.props;
@@ -236,33 +242,33 @@ class TextField extends Component {
         if (onEnterKey && event.key === 'Enter') {
             onEnterKey(event);
         }
-    }
+    };
 
     handleInputKeyPress = (event) => {
         const { onKeyPress } = this.props;
         if (onKeyPress) {
             onKeyPress(event.key, event);
         }
-    }
+    };
 
     handleInputKeyUp = (event) => {
         const { onKeyUp } = this.props;
         if (onKeyUp) {
             onKeyUp(event.key, event);
         }
-    }
+    };
 
     handleIconClick = () => {
         if (this.inputRef) {
             this.inputRef.focus();
         }
-    }
+    };
 
     handleClearIconClick = (event) => {
         this.clearInput();
         this.handleIconClick();
         this.handleInputChange(event);
-    }
+    };
 
     /**
      * wrapInputWithTooltip
@@ -292,7 +298,7 @@ class TextField extends Component {
                 </Tooltip> :
                 input
         );
-    }
+    };
 
     render() {
         const hasValue =
@@ -303,6 +309,9 @@ class TextField extends Component {
             this.state.hasMouseOver ||
             !hasValue
         );
+
+        const setClearButtonRef = this.props.clearButtonRef || (() => {});
+
         /* eslint-disable jsx-a11y/label-has-for */
         // @NB: jsx-a11y/label-has-for fails with UID as id
         const label = this.props.label && showLabel ?
@@ -361,6 +370,8 @@ class TextField extends Component {
                         icon={<IconClear />}
                         onClick={this.handleClearIconClick}
                         variant={ButtonVariant.CLEAR}
+                        tabIndex={this.props.clearButtonTabIndex}
+                        componentRef={(ref) => { setClearButtonRef(ref); }}
                     />
                 </span>
             ) :
@@ -419,6 +430,7 @@ class TextField extends Component {
                             required={this.props.isRequired}
                             ref={this.handleInputRef}
                             step={this.props.step}
+                            tabIndex={this.props.tabIndex}
                             type={this.props.type}
                             value={this.state.value === null ? '' : this.state.value}
                         />,

--- a/src/components/Fields/TextField.test.js
+++ b/src/components/Fields/TextField.test.js
@@ -283,9 +283,28 @@ describe('TextField', () => {
         expect(textField.find(TooltipBox).prop('status')).to.equal(TooltipBoxStatus.ERROR);
     });
 
+    it('defines tabIndex for the TextField', () => {
+        const tabIndexValue = 3;
+        const textField = mount(<TextField value="an example value" tabIndex={tabIndexValue} isClearable />);
+        expect(textField.prop('tabIndex')).to.equal(tabIndexValue);
+    });
+
     it('displays a clear icon if isClearable is given and textfield has a value', () => {
         const textField = mount(<TextField value="an example value" isClearable />);
         expect(textField.find(IconClear).length).to.equal(1);
+    });
+
+    it('calls clearButtonRef when the clear icon is rendered', () => {
+        const clearButtonRef = sinon.spy();
+        mount(<TextField value="an example value" clearButtonRef={clearButtonRef} isClearable />);
+        expect(clearButtonRef).to.be.calledOnce();
+    });
+
+    it('Defines tabIndex correctly for the clear button', () => {
+        const tabIndexValue = 2;
+        const textField = mount(<TextField value="an example value" clearButtonTabIndex={tabIndexValue} isClearable />);
+        const button = textField.find(Button);
+        expect(button.prop('tabIndex')).to.equal(tabIndexValue);
     });
 
     it('does not display a clear icon if isClearable is given but the textfield has no value', () => {


### PR DESCRIPTION
Adds `tabindex` and component `ref` for some fields

**Backwards Compatibility Implications** <!-- List backwards compatibility issues, or _None_ if there are none. -->

_None_

**New Features** <!-- List new features, or _None_ if there are none. -->
1. Clear button `ref` and `tabIndex` for `DateField`'s `TextField`
2. `Ref` and `tabIndex` for `DateField`'s `TextField`
3. Adding `tabIndex` for `TextArea`
4. Clear button `ref` and `tabIndex` for `TextField`

**Bug Fixes** <!-- List any bug fixes, or _None_ if there are none. -->

_None_
